### PR TITLE
refactor(output): centralize title formatting and empty list validati…

### DIFF
--- a/internal/services/compute/image/output.go
+++ b/internal/services/compute/image/output.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"fmt"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/printer"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
@@ -24,15 +22,7 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 		return util.MarshalDataToJSON[Image](p, images, pagination)
 	}
 
-	// Handle the case where no instances are found.
-	if len(images) == 0 {
-		fmt.Fprintln(appCtx.Stdout, "No instances found.") // Write to the context's writer.
-		if pagination != nil && pagination.TotalCount > 0 {
-			fmt.Fprintf(appCtx.Stdout, "Page %d is empty. Total records: %d\n", pagination.CurrentPage, pagination.TotalCount)
-			if pagination.CurrentPage > 1 {
-				fmt.Fprintf(appCtx.Stdout, "Try a lower page number (e.g., --page %d)\n", pagination.CurrentPage-1)
-			}
-		}
+	if util.ValidateAndReportEmpty(images, pagination, appCtx.Stdout) {
 		return nil
 	}
 
@@ -54,10 +44,8 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 		}
 
 		// Create the colored title using components from the app context.
-		coloredTenancy := text.Colors{text.FgMagenta}.Sprint(appCtx.TenancyName)
-		coloredCompartment := text.Colors{text.FgCyan}.Sprint(appCtx.CompartmentName)
-		coloredInstance := text.Colors{text.FgBlue}.Sprint(image.Name)
-		title := fmt.Sprintf("%s: %s: %s", coloredTenancy, coloredCompartment, coloredInstance)
+		title := util.FormatColoredTitle(appCtx, image.Name)
+
 		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, imageData, orderedKeys)
 	}

--- a/internal/services/compute/instance/output.go
+++ b/internal/services/compute/instance/output.go
@@ -2,7 +2,6 @@ package instance
 
 import (
 	"fmt"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/printer"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
@@ -25,14 +24,7 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 	}
 
 	// Handle the case where no instances are found.
-	if len(instances) == 0 {
-		fmt.Fprintln(appCtx.Stdout, "No instances found.") // Write to the context's writer.
-		if pagination != nil && pagination.TotalCount > 0 {
-			fmt.Fprintf(appCtx.Stdout, "Page %d is empty. Total records: %d\n", pagination.CurrentPage, pagination.TotalCount)
-			if pagination.CurrentPage > 1 {
-				fmt.Fprintf(appCtx.Stdout, "Try a lower page number (e.g., --page %d)\n", pagination.CurrentPage-1)
-			}
-		}
+	if util.ValidateAndReportEmpty(instances, pagination, appCtx.Stdout) {
 		return nil
 	}
 
@@ -139,11 +131,7 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 			orderedKeys = newOrderedKeys
 		}
 
-		// Create the colored title using components from the app context.
-		coloredTenancy := text.Colors{text.FgMagenta}.Sprint(appCtx.TenancyName)
-		coloredCompartment := text.Colors{text.FgCyan}.Sprint(appCtx.CompartmentName)
-		coloredInstance := text.Colors{text.FgBlue}.Sprint(instance.Name)
-		title := fmt.Sprintf("%s: %s: %s", coloredTenancy, coloredCompartment, coloredInstance)
+		title := util.FormatColoredTitle(appCtx, instance.Name)
 
 		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, instanceData, orderedKeys)

--- a/internal/services/compute/oke/find.go
+++ b/internal/services/compute/oke/find.go
@@ -32,7 +32,7 @@ func FindClusters(appCtx *app.ApplicationContext, namePattern string, useJSON bo
 		return nil
 	}
 
-	err = PrintOKEInfo(clusters, appCtx, useJSON)
+	err = PrintOKEInfo(clusters, appCtx, nil, useJSON)
 	if err != nil {
 		return fmt.Errorf("printing clusters: %w", err)
 	}

--- a/internal/services/compute/oke/list.go
+++ b/internal/services/compute/oke/list.go
@@ -21,7 +21,7 @@ func ListClusters(appCtx *app.ApplicationContext, useJSON bool) error {
 		return fmt.Errorf("listing oke clusters: %w", err)
 	}
 
-	err = PrintOKEInfo(clusters, appCtx, useJSON)
+	err = PrintOKEInfo(clusters, appCtx, nil, useJSON)
 	if err != nil {
 		return fmt.Errorf("printing clusters: %w", err)
 	}

--- a/internal/services/util/output.go
+++ b/internal/services/util/output.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/rozdolsky33/ocloud/internal/app"
+	"github.com/rozdolsky33/ocloud/internal/printer"
+)
+
+// MarshalDataToJSON now accepts a printer and returns an error.
+func MarshalDataToJSON[T any](p *printer.Printer, items []T, pagination *PaginationInfo) error {
+	response := JSONResponse[T]{
+		Items:      items,
+		Pagination: pagination,
+	}
+	return p.MarshalToJSON(response)
+}
+
+// FormatColoredTitle builds a colorized title string with tenancy, compartment, and cluster.
+func FormatColoredTitle(appCtx *app.ApplicationContext, name string) string {
+	// Create the colored title using components from the app context.
+	coloredTenancy := text.Colors{text.FgMagenta}.Sprint(appCtx.TenancyName)
+	coloredCompartment := text.Colors{text.FgCyan}.Sprint(appCtx.CompartmentName)
+	coloredName := text.Colors{text.FgBlue}.Sprint(name)
+	title := fmt.Sprintf("%s: %s: %s", coloredTenancy, coloredCompartment, coloredName)
+
+	return title
+}


### PR DESCRIPTION
…on logic

- Moved `FormatColoredTitle` and `ValidateAndReportEmpty` utilities to the `util` package for reuse across services.
- Replaced duplicated title formatting and empty list handling code in multiple services (`OKE`, `images`, and `instances`) with centralized utility calls.
- Simplified JSON marshaling for cluster, image, and instance services by utilizing the `MarshalDataToJSON` utility.