### PR TITLE
feat(display): add OCI auth refresher status check to configuration output

### DIFF
--- a/Formula/ocloud.rb
+++ b/Formula/ocloud.rb
@@ -5,12 +5,12 @@
 class Ocloud < Formula
   desc "Tool for finding and connecting to OCI instances"
   homepage "https://github.com/rozdolsky33/ocloud"
-  version "0.0.18"
+  version "0.0.19"
   license "MIT"
 
   on_macos do
-    url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.18/ocloud_0.0.18_darwin_all.tar.gz"
-    sha256 "fb53108aa83865991cef381730737caed1faefdc51a6848eb206c7d9097258b9"
+    url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.19/ocloud_0.0.19_darwin_all.tar.gz"
+    sha256 "c72898d8a30c2397b1c5d6947d6584878a1bb8cbad85461fb26c8e3e483c0ed5"
 
     def install
       bin.install "ocloud"
@@ -19,15 +19,15 @@ class Ocloud < Formula
 
   on_linux do
     if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.18/ocloud_0.0.18_linux_amd64.tar.gz"
-      sha256 "16a30aad1b80026eb38d5b2565e1272e5c17eb0810ee3674bacfcd93ae2ceb99"
+      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.19/ocloud_0.0.19_linux_amd64.tar.gz"
+      sha256 "de0df059272b4e96769881c81fbbb86a3df7ec398156113bc3db3bb2a0f9969c"
       def install
         bin.install "ocloud"
       end
     end
     if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.18/ocloud_0.0.18_linux_arm64.tar.gz"
-      sha256 "5d5e0b9dff4f71750b88d510dc2c3b5de5edeb90e015804623cd0fc3d5ad11c9"
+      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.19/ocloud_0.0.19_linux_arm64.tar.gz"
+      sha256 "8c40cd56741d01e729c14cf7bda013bf09671fffe2988ea8fa1366936dc0c722"
       def install
         bin.install "ocloud"
       end

--- a/cmd/shared/display/display.go
+++ b/cmd/shared/display/display.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rozdolsky33/ocloud/internal/config/flags"
 )
 
-// Color functions for better Windows terminal support
 var (
 	boldStyle    = color.New(color.Bold)
 	redStyle     = color.New(color.FgRed)

--- a/cmd/shared/display/display.go
+++ b/cmd/shared/display/display.go
@@ -49,6 +49,21 @@ func CheckOCISessionValidity() string {
 	}
 }
 
+// CheckOCIAuthRefresherStatus checks if the OCI auth refresher script is running
+func CheckOCIAuthRefresherStatus() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "pgrep", "-af", "oci_auth_refresher.sh")
+	out, err := cmd.CombinedOutput()
+
+	if err == nil && len(strings.TrimSpace(string(out))) > 0 {
+		return greenStyle.Sprint("ON")
+	} else {
+		return redStyle.Sprint("OFF")
+	}
+}
+
 // PrintOCIConfiguration displays the current configuration details
 // and checks if required environment variables are set
 func PrintOCIConfiguration() {
@@ -77,6 +92,9 @@ func PrintOCIConfiguration() {
 	} else {
 		fmt.Printf("  %s: %s\n", yellowStyle.Sprint(flags.EnvKeyCompartment), compartment)
 	}
+
+	refresherStatus := CheckOCIAuthRefresherStatus()
+	fmt.Printf("  %s: %s\n", yellowStyle.Sprint(flags.EnvKeyAutoRefresher), refresherStatus)
 
 	path := config.TenancyMapPath()
 	_, err := os.Stat(path)

--- a/internal/config/flags/constants.go
+++ b/internal/config/flags/constants.go
@@ -84,6 +84,7 @@ const (
 	EnvKeyCLITenancy     = "OCI_CLI_TENANCY"
 	EnvKeyTenancyName    = "OCI_TENANCY_NAME"
 	EnvKeyCompartment    = "OCI_COMPARTMENT"
+	EnvKeyAutoRefresher  = "OCI_AUTH_AUTO_REFRESHER"
 	EnvKeyRegion         = "OCI_REGION"
 	EnvKeyTenancyMapPath = "OCI_TENANCY_MAP_PATH"
 )


### PR DESCRIPTION
- Introduced `CheckOCIAuthRefresherStatus` to verify the status of the refresher script.
- Updated `PrintOCIConfiguration` to display the new status with color-coded feedback.