### PR TITLE
refactor: reorder and organize imports across multiple files

### DIFF
--- a/.github/badges/downloads.json
+++ b/.github/badges/downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "downloads",
-  "message": "172",
+  "message": "174",
   "color": "blue"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
       - "develop"
       - 'feature-*'
       - 'feature/*'
+      - "refactor/*"
+      - "refactor-*"
     paths-ignore:
       - 'README.md'
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ REPORT-V2.md
 REPORT.md
 test_ocloud_README.md
 docs/TECHNICAL_OVERVIEW_v2.md
+replace_repo_path.sh

--- a/Formula/ocloud.rb
+++ b/Formula/ocloud.rb
@@ -5,12 +5,12 @@
 class Ocloud < Formula
   desc "Tool for finding and connecting to OCI instances"
   homepage "https://github.com/rozdolsky33/ocloud"
-  version "0.0.26"
+  version "0.0.27"
   license "MIT"
 
   on_macos do
-    url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.26/ocloud_0.0.26_darwin_all.tar.gz"
-    sha256 "34abd88dbc5a62d481f4d8e4c8b5b2695d9fd9e9ab8b6fc8f181d074cf7860de"
+    url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.27/ocloud_0.0.27_darwin_all.tar.gz"
+    sha256 "70ea8b240ffbe96423dde8d40fe6b8aa5fad26d343eaae93d8c7b8b9893eca33"
 
     def install
       bin.install "ocloud"
@@ -19,15 +19,15 @@ class Ocloud < Formula
 
   on_linux do
     if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.26/ocloud_0.0.26_linux_amd64.tar.gz"
-      sha256 "c9e341ca940f9bec7b8be07a3891b375c586c48ef240cd77b33ec458724e9279"
+      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.27/ocloud_0.0.27_linux_amd64.tar.gz"
+      sha256 "1d3336ae4ed1b0f850581d468987a1118cae45c7681aaf3655dce5e74812f046"
       def install
         bin.install "ocloud"
       end
     end
     if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.26/ocloud_0.0.26_linux_arm64.tar.gz"
-      sha256 "c8bdbcd2756056eb288821cbb551f6c2df70c3e40a3625b20e03ac2de029300a"
+      url "https://github.com/rozdolsky33/ocloud/releases/download/v0.0.27/ocloud_0.0.27_linux_arm64.tar.gz"
+      sha256 "a2b714480b66d720f5c3b695f9bfe095a88b8b5ac6d4492d2e9ea0001f86604f"
       def install
         bin.install "ocloud"
       end

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ brew install ocloud
 
 ### Manual Installation
 
-Download the latest binary from the [releases page](https://github.com/rozdolsky33/ocloud/releases) and place it in your PATH.
+Download the latest binary from the [release page](https://github.com/rozdolsky33/ocloud/releases) and place it in your PATH.
 
 #### macOS/Linux
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,6 @@ sudo xattr -d com.apple.quarantine ~/.local/bin/ocloud
 chmod +x ~/.local/bin/ocloud
 ```
 
-#### Windows
-
-1. Download the Windows binary from the release page
-2. Add the location to your PATH environment variable
-3. Launch a new console session to apply the updated environment variable
 
 ### Build from Source
 

--- a/cmd/compute/image/find.go
+++ b/cmd/compute/image/find.go
@@ -66,8 +66,6 @@ func NewFindCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationContext) error {
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	// Use LogWithLevel to ensure debug logs work with shorthand flags
 	logger.LogWithLevel(logger.CmdLogger, 1, "Running image find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
 	return image.FindImages(appCtx, namePattern, useJSON)
 }

--- a/cmd/compute/image/get.go
+++ b/cmd/compute/image/get.go
@@ -9,10 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Dedicated documentation for the get command
 var listLong = `
-List all images in the specified compartment with pagination support.
+Get images in the specified compartment with pagination support.
 
-This command displays information about available images in the current compartment.
+This command retrieves available images in the current compartment.
 By default, it shows basic image information such as name, ID, operating system, and launch mode.
 
 The output is paginated, with a default limit of 20 images per page. You can navigate
@@ -25,17 +26,17 @@ Additional Information:
 `
 
 var listExamples = `
-  # List all images with default pagination (20 per page)
-  ocloud compute image list
+  # Get images with default pagination (20 per page)
+  ocloud compute image get
 
-  # List images with custom pagination (10 per page, page 2)
-  ocloud compute image list --limit 10 --page 2
+  # Get images with custom pagination (10 per page, page 2)
+  ocloud compute image get --limit 10 --page 2
 
-  # List images and output in JSON format
-  ocloud compute image list --json
+  # Get images and output in JSON format
+  ocloud compute image get --json
 
-  # List images with custom pagination and JSON output
-  ocloud compute image list --limit 5 --page 3 --json
+  # Get images with custom pagination and JSON output
+  ocloud compute image get --limit 5 --page 3 --json
 `
 
 // NewGetCmd creates a new command for listing images

--- a/cmd/compute/image/get.go
+++ b/cmd/compute/image/get.go
@@ -1,0 +1,70 @@
+package image
+
+import (
+	paginationFlags "github.com/rozdolsky33/ocloud/cmd/flags"
+	"github.com/rozdolsky33/ocloud/internal/app"
+	"github.com/rozdolsky33/ocloud/internal/config/flags"
+	"github.com/rozdolsky33/ocloud/internal/logger"
+	"github.com/rozdolsky33/ocloud/internal/services/compute/image"
+	"github.com/spf13/cobra"
+)
+
+var listLong = `
+List all images in the specified compartment with pagination support.
+
+This command displays information about available images in the current compartment.
+By default, it shows basic image information such as name, ID, operating system, and launch mode.
+
+The output is paginated, with a default limit of 20 images per page. You can navigate
+through pages using the --page flag and control the number of images per page with
+the --limit flag.
+
+Additional Information:
+- Use --json (-j) to output the results in JSON format
+- The command shows all available images in the compartment
+`
+
+var listExamples = `
+  # List all images with default pagination (20 per page)
+  ocloud compute image list
+
+  # List images with custom pagination (10 per page, page 2)
+  ocloud compute image list --limit 10 --page 2
+
+  # List images and output in JSON format
+  ocloud compute image list --json
+
+  # List images with custom pagination and JSON output
+  ocloud compute image list --limit 5 --page 3 --json
+`
+
+// NewGetCmd creates a new command for listing images
+func NewGetCmd(appCtx *app.ApplicationContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "get",
+		Short:         "Get all images",
+		Long:          listLong,
+		Example:       listExamples,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunGetCommand(cmd, appCtx)
+		},
+	}
+
+	paginationFlags.LimitFlag.Add(cmd)
+	paginationFlags.PageFlag.Add(cmd)
+
+	return cmd
+}
+
+// RunGetCommand handles the execution of the list command
+func RunGetCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
+
+	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
+	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
+	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
+
+	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON)
+	return image.GetImages(appCtx, limit, page, useJSON)
+}

--- a/cmd/compute/image/get_test.go
+++ b/cmd/compute/image/get_test.go
@@ -14,7 +14,7 @@ func TestListCommand(t *testing.T) {
 	appCtx := &app.ApplicationContext{}
 
 	// Create a new list command
-	cmd := NewListCmd(appCtx)
+	cmd := NewGetCmd(appCtx)
 
 	// Test that the list command is properly configured
 	assert.Equal(t, "list", cmd.Use)

--- a/cmd/compute/image/get_test.go
+++ b/cmd/compute/image/get_test.go
@@ -17,9 +17,8 @@ func TestListCommand(t *testing.T) {
 	cmd := NewGetCmd(appCtx)
 
 	// Test that the list command is properly configured
-	assert.Equal(t, "list", cmd.Use)
-	assert.Equal(t, []string{"l"}, cmd.Aliases)
-	assert.Equal(t, "List all images", cmd.Short)
+	assert.Equal(t, "get", cmd.Use)
+	assert.Equal(t, "Get all images", cmd.Short)
 	assert.Equal(t, listLong, cmd.Long)
 	assert.Equal(t, listExamples, cmd.Example)
 	assert.True(t, cmd.SilenceUsage)

--- a/cmd/compute/image/list.go
+++ b/cmd/compute/image/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Long description for the list command
 var listLong = `
 List all images in the specified compartment with pagination support.
 
@@ -25,7 +24,6 @@ Additional Information:
 - The command shows all available images in the compartment
 `
 
-// Examples for the list command
 var listExamples = `
   # List all images with default pagination (20 per page)
   ocloud compute image list
@@ -55,7 +53,6 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		},
 	}
 
-	// Add flags specific to the list command
 	paginationFlags.LimitFlag.Add(cmd)
 	paginationFlags.PageFlag.Add(cmd)
 
@@ -65,7 +62,6 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 // RunListCommand handles the execution of the list command
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 
-	// Get pagination parameters
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)

--- a/cmd/compute/image/list.go
+++ b/cmd/compute/image/list.go
@@ -1,51 +1,19 @@
 package image
 
 import (
-	paginationFlags "github.com/rozdolsky33/ocloud/cmd/flags"
 	"github.com/rozdolsky33/ocloud/internal/app"
-	"github.com/rozdolsky33/ocloud/internal/config/flags"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/rozdolsky33/ocloud/internal/services/compute/image"
 	"github.com/spf13/cobra"
 )
 
-var listLong = `
-List all images in the specified compartment with pagination support.
-
-This command displays information about available images in the current compartment.
-By default, it shows basic image information such as name, ID, operating system, and launch mode.
-
-The output is paginated, with a default limit of 20 images per page. You can navigate
-through pages using the --page flag and control the number of images per page with
-the --limit flag.
-
-Additional Information:
-- Use --json (-j) to output the results in JSON format
-- The command shows all available images in the compartment
-`
-
-var listExamples = `
-  # List all images with default pagination (20 per page)
-  ocloud compute image list
-
-  # List images with custom pagination (10 per page, page 2)
-  ocloud compute image list --limit 10 --page 2
-
-  # List images and output in JSON format
-  ocloud compute image list --json
-
-  # List images with custom pagination and JSON output
-  ocloud compute image list --limit 5 --page 3 --json
-`
-
 // NewListCmd creates a new command for listing images
 func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "list",
-		Aliases:       []string{"l"},
 		Short:         "List all images",
-		Long:          listLong,
-		Example:       listExamples,
+		Long:          " ",
+		Example:       " ",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,19 +21,12 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		},
 	}
 
-	paginationFlags.LimitFlag.Add(cmd)
-	paginationFlags.PageFlag.Add(cmd)
-
 	return cmd
 }
 
 // RunListCommand handles the execution of the list command
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-
-	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
-	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
-	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON)
-	return image.ListImages(appCtx, limit, page, useJSON)
+	ctx := cmd.Context()
+	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName)
+	return image.ListImages(ctx, appCtx)
 }

--- a/cmd/compute/image/list.go
+++ b/cmd/compute/image/list.go
@@ -7,13 +7,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Dedicated documentation for the list command (separate from get)
+var listCmdLong = `
+Interactively browse and search images in the specified compartment using a TUI.
+
+This command launches a Bubble Tea-based terminal UI that loads available images and lets you:
+- Search/filter images as you type
+- Navigate the list
+- Select a single image to view its details
+
+After you pick an image, the tool prints detailed information about the selected image.
+`
+
+var listCmdExamples = `
+  # Launch the interactive image browser
+  ocloud compute image list
+
+  # Use fuzzy search in the UI to quickly find what you need
+  ocloud compute image list
+`
+
 // NewListCmd creates a new command for listing images
 func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "list",
 		Short:         "List all images",
-		Long:          " ",
-		Example:       " ",
+		Aliases:       []string{"l"},
+		Long:          listCmdLong,
+		Example:       listCmdExamples,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -24,9 +45,9 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 	return cmd
 }
 
-// RunListCommand handles the execution of the list command
+// RunListCommand executes the interactive TUI image lister
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	ctx := cmd.Context()
-	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName)
+	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list (TUI) command in", "compartment", appCtx.CompartmentName)
 	return image.ListImages(ctx, appCtx)
 }

--- a/cmd/compute/image/list_test.go
+++ b/cmd/compute/image/list_test.go
@@ -35,7 +35,4 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(t, pageFlag, "list command should have page flag")
 	assert.Equal(t, "page", pageFlag.Name)
 	assert.Equal(t, "p", pageFlag.Shorthand)
-
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
-	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/compute/image/root.go
+++ b/cmd/compute/image/root.go
@@ -17,7 +17,6 @@ func NewImageCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Add subcommands
 	cmd.AddCommand(NewListCmd(appCtx))
 	cmd.AddCommand(NewFindCmd(appCtx))
 

--- a/cmd/compute/image/root.go
+++ b/cmd/compute/image/root.go
@@ -17,8 +17,9 @@ func NewImageCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	cmd.AddCommand(NewListCmd(appCtx))
+	cmd.AddCommand(NewGetCmd(appCtx))
 	cmd.AddCommand(NewFindCmd(appCtx))
+	cmd.AddCommand(NewListCmd(appCtx))
 
 	return cmd
 }

--- a/cmd/compute/image/root_test.go
+++ b/cmd/compute/image/root_test.go
@@ -27,30 +27,39 @@ func TestImageCommand(t *testing.T) {
 	assert.True(t, cmd.SilenceErrors)
 	assert.Nil(t, cmd.RunE, "RunE should be nil since the root command now has subcommands")
 
-	// Test that the subcommands are added
+	// Test that the list subcommand is added and configured (TUI, no pagination flags)
 	listCmd := findSubCommand(cmd, "list")
 	assert.NotNil(t, listCmd, "list subcommand should be added")
 	assert.Equal(t, "List all images", listCmd.Short)
 	assert.NotNil(t, listCmd.RunE, "list subcommand should have a RunE function")
 
-	// Test that the list subcommand has the appropriate flags
-	limitFlag := listCmd.Flags().Lookup(flags.FlagNameLimit)
-	assert.NotNil(t, limitFlag, "limit flag should be added to list subcommand")
-	assert.Equal(t, flags.FlagShortLimit, limitFlag.Shorthand)
-	assert.Equal(t, flags.FlagDescLimit, limitFlag.Usage)
-
-	pageFlag := listCmd.Flags().Lookup(flags.FlagNamePage)
-	assert.NotNil(t, pageFlag, "page flag should be added to list subcommand")
-	assert.Equal(t, flags.FlagShortPage, pageFlag.Shorthand)
-	assert.Equal(t, flags.FlagDescPage, pageFlag.Usage)
-
-	// JSON flag is now a global flag, so it should not be in the local flags
+	// JSON flag is now a global flag, so it should not be in the local flags for a list
 	jsonFlag := listCmd.Flags().Lookup(flags.FlagNameJSON)
 	assert.Nil(t, jsonFlag, "json flag should not be added as a local flag to list subcommand")
 
 	// But we should still be able to get its value using flags.GetBoolFlag
 	useJSON := flags.GetBoolFlag(listCmd, flags.FlagNameJSON, false)
 	assert.False(t, useJSON, "default value of json flag should be false")
+
+	// Test that the get subcommand is added and has pagination flags
+	getCmd := findSubCommand(cmd, "get")
+	assert.NotNil(t, getCmd, "get subcommand should be added")
+	assert.Equal(t, "Get all images", getCmd.Short)
+	assert.NotNil(t, getCmd.RunE, "get subcommand should have a RunE function")
+
+	limitFlag := getCmd.Flags().Lookup(flags.FlagNameLimit)
+	assert.NotNil(t, limitFlag, "limit flag should be added to get subcommand")
+	assert.Equal(t, flags.FlagShortLimit, limitFlag.Shorthand)
+	assert.Equal(t, flags.FlagDescLimit, limitFlag.Usage)
+
+	pageFlag := getCmd.Flags().Lookup(flags.FlagNamePage)
+	assert.NotNil(t, pageFlag, "page flag should be added to get subcommand")
+	assert.Equal(t, flags.FlagShortPage, pageFlag.Shorthand)
+	assert.Equal(t, flags.FlagDescPage, pageFlag.Usage)
+
+	// JSON flag is global, so it should not be in the local flags for get either
+	jsonFlagGet := getCmd.Flags().Lookup(flags.FlagNameJSON)
+	assert.Nil(t, jsonFlagGet, "json flag should not be added as a local flag to get subcommand")
 
 	// Test that the find subcommand is added
 	findCmd := findSubCommand(cmd, "find")

--- a/cmd/compute/instance/find.go
+++ b/cmd/compute/instance/find.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Long description for the find command
 var findLong = `
 Find instances in the specified compartment that match the given pattern.
 
@@ -25,7 +24,6 @@ The search pattern is automatically wrapped with wildcards, so partial matches a
 For example, searching for "web" will match "webserver" etc.
 `
 
-// Examples for the find command
 var findExamples = `
   # Find instances with "web" in their name
   ocloud compute instance find web
@@ -70,8 +68,6 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	namePattern := args[0]
 	imageDetails := flags.GetBoolFlag(cmd, flags.FlagNameAllInformation, false)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	// Use LogWithLevel to ensure debug logs work with shorthand flags
 	logger.LogWithLevel(logger.CmdLogger, 1, "Running instance find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
 	return instance.FindInstances(appCtx, namePattern, imageDetails, useJSON)
 }

--- a/cmd/compute/instance/list.go
+++ b/cmd/compute/instance/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Long description for the list command
 var listLong = `
 List all instances in the specified compartment with pagination support.
 
@@ -27,7 +26,6 @@ Additional Information:
 - The command only shows running instances by default
 `
 
-// Examples for the list command
 var listExamples = `
   # List all instances with default pagination (20 per page)
   ocloud compute instance list
@@ -63,7 +61,6 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		},
 	}
 
-	// Add flags specific to the list command
 	paginationFlags.LimitFlag.Add(cmd)
 	paginationFlags.PageFlag.Add(cmd)
 	instaceFlags.ImageDetailsFlag.Add(cmd)
@@ -73,13 +70,11 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 
 // RunListCommand handles the execution of the list command
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-	// Get pagination parameters
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	imageDetails := flags.GetBoolFlag(cmd, flags.FlagNameAllInformation, false)
 
-	// Use LogWithLevel to ensure debug logs work with shorthand flags
 	logger.LogWithLevel(logger.CmdLogger, 1, "Running instance list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON, "imageDetails", imageDetails)
 	return instance.ListInstances(appCtx, limit, page, useJSON, imageDetails)
 }

--- a/cmd/compute/instance/list_test.go
+++ b/cmd/compute/instance/list_test.go
@@ -36,7 +36,7 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "page", pageFlag.Name)
 	assert.Equal(t, "p", pageFlag.Shorthand)
 
-	// Test that the all flag is added (used for image details)
+	// Test that the all flags are added (used for image details)
 	imageDetailsFlag := cmd.Flag("all")
 	assert.NotNil(t, imageDetailsFlag, "list command should have all flag (used for image details)")
 	assert.Equal(t, "all", imageDetailsFlag.Name)

--- a/cmd/compute/instance/root.go
+++ b/cmd/compute/instance/root.go
@@ -18,7 +18,6 @@ func NewInstanceCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Add subcommands
 	cmd.AddCommand(NewListCmd(appCtx))
 	cmd.AddCommand(NewFindCmd(appCtx))
 

--- a/cmd/compute/oke/find.go
+++ b/cmd/compute/oke/find.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Long description for the find command
 var findLong = `
 Find Oracle Kubernetes Engine (OKE) clusters in the specified compartment that match the given pattern.
 
@@ -24,7 +23,6 @@ Additional Information:
 - The command searches across all available clusters in the compartment
 `
 
-// Examples for the find command
 var findExamples = `
   # Find clusters with names containing "prod"
   ocloud compute oke find prod
@@ -59,8 +57,6 @@ func NewFindCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationContext) error {
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	// Use LogWithLevel to ensure debug logs work with shorthand flags
 	logger.LogWithLevel(logger.CmdLogger, 1, "Running oke find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
 	return oke.FindClusters(appCtx, namePattern, useJSON)
 }

--- a/cmd/compute/oke/find_test.go
+++ b/cmd/compute/oke/find_test.go
@@ -27,6 +27,4 @@ func TestFindCommand(t *testing.T) {
 	// Verify that the command requires exactly one argument
 	assert.NotNil(t, cmd.Args)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the find.go file.
-	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/compute/oke/list.go
+++ b/cmd/compute/oke/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Long description for the list command
 var listLong = `
 List all Oracle Kubernetes Engine (OKE) clusters in the specified compartment.
 
@@ -23,7 +22,6 @@ Additional Information:
 - Use --page (-p) to navigate between pages of results
 `
 
-// Examples for the list command
 var listExamples = `
   # List all OKE clusters in the current compartment
   ocloud compute oke list

--- a/cmd/compute/oke/list_test.go
+++ b/cmd/compute/oke/list_test.go
@@ -36,6 +36,4 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "page", pageFlag.Name)
 	assert.Equal(t, "p", pageFlag.Shorthand)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
-	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/compute/oke/root.go
+++ b/cmd/compute/oke/root.go
@@ -16,7 +16,6 @@ func NewOKECmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Add subcommands
 	cmd.AddCommand(NewListCmd(appCtx))
 	cmd.AddCommand(NewFindCmd(appCtx))
 

--- a/cmd/compute/root.go
+++ b/cmd/compute/root.go
@@ -20,7 +20,6 @@ func NewComputeCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Add subcommands, passing in the ApplicationContext
 	cmd.AddCommand(instance.NewInstanceCmd(appCtx))
 	cmd.AddCommand(image.NewImageCmd(appCtx))
 	cmd.AddCommand(oke.NewOKECmd(appCtx))

--- a/cmd/identity/bastion/flows_instance.go
+++ b/cmd/identity/bastion/flows_instance.go
@@ -27,8 +27,19 @@ func connectInstance(ctx context.Context, appCtx *app.ApplicationContext, svc *b
 	if err != nil {
 		return fmt.Errorf("list instances: %w", err)
 	}
+
 	if len(instances) == 0 {
 		fmt.Println("No instances found.")
+		return nil
+	}
+
+	enabledInstances, err := svc.FilterInstancesWithBastionEnabled(ctx, instances)
+	if err != nil {
+		return fmt.Errorf("filtering instances: %w", err)
+	}
+
+	if len(enabledInstances) == 0 {
+		fmt.Println("No instances with Bastion enabled.")
 		return nil
 	}
 
@@ -49,7 +60,6 @@ func connectInstance(ctx context.Context, appCtx *app.ApplicationContext, svc *b
 		return err
 	}
 
-	// Find selection
 	var inst instancessvc.Instance
 	for _, it := range instances {
 		if it.ID == chosen.Choice() {
@@ -58,7 +68,6 @@ func connectInstance(ctx context.Context, appCtx *app.ApplicationContext, svc *b
 		}
 	}
 
-	// Reachability
 	if ok, reason := svc.CanReach(ctx, b, inst.VcnID, inst.SubnetID); !ok {
 		fmt.Println("Bastion cannot reach selected instance:", reason)
 		return nil
@@ -110,7 +119,6 @@ func connectInstance(ctx context.Context, appCtx *app.ApplicationContext, svc *b
 		}
 		log.Printf("spawned tunnel pid=%d", pid)
 
-		// (optional)
 		if err := bastionSvc.WaitForListen(defaultPort, 5*time.Second); err != nil {
 			log.Printf("warning: %v", err)
 		}

--- a/cmd/identity/bastion/flows_instance.go
+++ b/cmd/identity/bastion/flows_instance.go
@@ -33,16 +33,6 @@ func connectInstance(ctx context.Context, appCtx *app.ApplicationContext, svc *b
 		return nil
 	}
 
-	enabledInstances, err := svc.FilterInstancesWithBastionEnabled(ctx, instances)
-	if err != nil {
-		return fmt.Errorf("filtering instances: %w", err)
-	}
-
-	if len(enabledInstances) == 0 {
-		fmt.Println("No instances with Bastion enabled.")
-		return nil
-	}
-
 	// TUI selection
 	im := NewInstanceListModelFancy(instances)
 	ip := tea.NewProgram(im, tea.WithContext(ctx))

--- a/cmd/identity/bastion/flows_oke.go
+++ b/cmd/identity/bastion/flows_oke.go
@@ -136,10 +136,10 @@ func connectOKE(ctx context.Context, appCtx *app.ApplicationContext, svc *bastio
 	case TypePortForwarding:
 		// For PF: resolve endpoint -> private IP, then tunnel to 6443
 		candidates := []string{}
-		if h := extractHostname(cluster.PrivateEndpoint); h != "" {
+		if h := util.ExtractHostname(cluster.PrivateEndpoint); h != "" {
 			candidates = append(candidates, h)
 		}
-		if h := extractHostname(cluster.KubernetesEndpoint); h != "" {
+		if h := util.ExtractHostname(cluster.KubernetesEndpoint); h != "" {
 			candidates = append(candidates, h)
 		}
 		if len(candidates) == 0 {
@@ -150,7 +150,7 @@ func connectOKE(ctx context.Context, appCtx *app.ApplicationContext, svc *bastio
 		var targetIP string
 		var lastErr error
 		for _, host := range candidates {
-			ip, err := resolveHostToIP(ctx, host) // ctx-aware DNS
+			ip, err := util.ResolveHostToIP(ctx, host) // ctx-aware DNS
 			if err == nil {
 				targetIP = ip
 				break
@@ -182,7 +182,7 @@ func connectOKE(ctx context.Context, appCtx *app.ApplicationContext, svc *bastio
 			return fmt.Errorf("read port: %w", err)
 		}
 
-		if IsLocalTCPPortInUse(port) {
+		if util.IsLocalTCPPortInUse(port) {
 			return fmt.Errorf("local port %d is already in use on 127.0.0.1; choose another port", port)
 		}
 

--- a/cmd/identity/compartment/list_test.go
+++ b/cmd/identity/compartment/list_test.go
@@ -36,6 +36,6 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "page", pageFlag.Name)
 	assert.Equal(t, "p", pageFlag.Shorthand)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
+	// Note: The JSON flag is a global flag and is not directly added to the command in the get.go file.
 	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/network/subnet/list_test.go
+++ b/cmd/network/subnet/list_test.go
@@ -41,6 +41,6 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "sort", sortFlag.Name)
 	assert.Equal(t, "s", sortFlag.Shorthand)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
+	// Note: The JSON flag is a global flag and is not directly added to the command in the get.go file.
 	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/shared/cmdcreate/cmdcreate.go
+++ b/cmd/shared/cmdcreate/cmdcreate.go
@@ -49,10 +49,8 @@ func CreateRootCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func CreateRootCmdWithoutContext() *cobra.Command {
 	rootCmd := CreateRootCmd(nil)
 
-	// Add placeholder commands for help display
 	addPlaceholderCommands(rootCmd)
 
-	// Set the default behavior to show help
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
@@ -63,7 +61,6 @@ func CreateRootCmdWithoutContext() *cobra.Command {
 // addPlaceholderCommands adds placeholder commands that will be displayed in help
 // but will show a message about needing to initialize if they're actually run
 func addPlaceholderCommands(rootCmd *cobra.Command) {
-	// Define command types to add placeholders for
 	commandTypes := []struct {
 		use   string
 		short string
@@ -74,7 +71,6 @@ func addPlaceholderCommands(rootCmd *cobra.Command) {
 		{"network", "Manage OCI networking services"},
 	}
 
-	// Add placeholder commands
 	for _, cmdType := range commandTypes {
 		cmd := &cobra.Command{
 			Use:   cmdType.use,

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -22,7 +22,6 @@ type VersionInfo struct {
 // This function was refactored to return *cobra.Command directly instead of *VersionInfo
 // to fix an issue with adding the command to the root command
 func NewVersionCommand() *cobra.Command {
-	// If appCtx is nil, use os.Stdout as the default writer
 	var writer io.Writer = os.Stdout
 
 	vc := &VersionInfo{

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -70,8 +70,6 @@ func PrintVersion() {
 // AddVersionFlag adds a version flag to the root command
 // This function adds a global persistent flag to support the --version/-v flag
 // and sets up a PersistentPreRunE hook to check for the flag and print version information
-// Note: This function preserves any existing PersistentPreRunE hook by storing it and
-// calling it after checking for the version flag
 func AddVersionFlag(rootCmd *cobra.Command) {
 	// Register a global persistent flag to support short form (e.g., `ocloud -v`)
 	rootCmd.PersistentFlags().BoolP(flags.FlagNameVersion, flags.FlagShortVersion, false, flags.FlagDescVersion)

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -90,7 +90,7 @@ func determineConcurrencyStatus(cmd *cobra.Command) bool {
 		}
 	}
 
-	return true // default to enabled
+	return true
 }
 
 // resolveTenancyAndCompartment resolves the tenancy ID, tenancy name, and compartment ID for the application context.
@@ -141,9 +141,7 @@ func resolveTenancyID(cmd *cobra.Command) (string, error) {
 	if envTenancyName := os.Getenv(flags.EnvKeyTenancyName); envTenancyName != "" {
 		lookupID, err := config.LookupTenancyID(envTenancyName)
 		if err != nil {
-			// Log the error but continue with the next method of resolving the tenancy ID
 			logger.LogWithLevel(logger.CmdLogger, 3, "could not look up tenancy ID for tenancy name, continuing with other methods", "tenancyName", envTenancyName, "error", err)
-			// Add a more detailed message about how to set up the mapping file
 			logger.LogWithLevel(logger.CmdLogger, 3, "To set up tenancy mapping, create a YAML file at ~/.oci/tenancy-map.yaml or set the OCI_TENANCY_MAP_PATH environment variable. The file should contain entries mapping tenancy names to OCIDs. Example:\n- environment: prod\n  tenancy: mytenancy\n  tenancy_id: ocid1.tenancy.oc1..aaaaaaaabcdefghijklmnopqrstuvwxyz\n  realm: oc1\n  compartments: mycompartment\n  regions: us-ashburn-1")
 		} else {
 			logger.LogWithLevel(logger.CmdLogger, 3, "using tenancy OCID for name", "tenancyName", envTenancyName, "tenancyID", lookupID)
@@ -221,7 +219,6 @@ func resolveCompartmentID(ctx context.Context, appCtx *ApplicationContext) (stri
 		CompartmentIdInSubtree: common.Bool(true),
 	}
 
-	// paginate through results; stop when OpcNextPage is nil
 	pageToken := ""
 	for {
 		if pageToken != "" {

--- a/internal/config/oci_config.go
+++ b/internal/config/oci_config.go
@@ -71,7 +71,6 @@ func GetTenancyOCID() (string, error) {
 		return MockGetTenancyOCID()
 	}
 
-	// Normal implementation
 	id, err := LoadOCIConfig().TenancyOCID()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to retrieve tenancy OCID from OCI config")
@@ -87,7 +86,6 @@ func LookupTenancyID(tenancyName string) (string, error) {
 		return MockLookupTenancyID(tenancyName)
 	}
 
-	// Normal implementation
 	path := TenancyMapPath()
 	logger.LogWithLevel(logger.Logger, 3, "looking up tenancy in map", "tenancy", tenancyName, "path", path)
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -99,7 +99,7 @@ func TestSetLogger(t *testing.T) {
 		CmdLogger = originalCmdLogger
 	}()
 
-	// Test with valid log level
+	// Test with a valid log level
 	LogLevel = "info"
 	ColoredOutput = false
 	err := SetLogger()

--- a/internal/logger/test_logger.go
+++ b/internal/logger/test_logger.go
@@ -1,9 +1,10 @@
 package logger
 
 import (
-	"github.com/go-logr/logr"
 	"io"
 	"log/slog"
+
+	"github.com/go-logr/logr"
 )
 
 // NewTestLogger creates a logger suitable for testing that doesn't produce output.

--- a/internal/services/compute/image/find_simple_test.go
+++ b/internal/services/compute/image/find_simple_test.go
@@ -1,11 +1,12 @@
 package image
 
 import (
+	"io"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"testing"
 )
 
 // TestFindImagesSimple is a simplified test for the FindImages function

--- a/internal/services/compute/image/get.go
+++ b/internal/services/compute/image/get.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rozdolsky33/ocloud/internal/app"
+	"github.com/rozdolsky33/ocloud/internal/logger"
+	"github.com/rozdolsky33/ocloud/internal/services/util"
+)
+
+// GetImages retrieves and displays a list of images, utilizing pagination, sorting, and optional JSON output.
+// It uses the application context for accessing configurations, logging, and output streams.
+func GetImages(appCtx *app.ApplicationContext, limit int, page int, useJSON bool) error {
+	logger.LogWithLevel(appCtx.Logger, 1, "ListImages", "limit", limit, "page", page, "json", useJSON)
+
+	service, err := NewService(appCtx)
+	if err != nil {
+		return fmt.Errorf("creating compute service: %w", err)
+	}
+
+	ctx := context.Background()
+	images, totalCount, nextPageToken, err := service.Get(ctx, limit, page)
+	if err != nil {
+		return fmt.Errorf("listing images: %w", err)
+	}
+
+	// Display image information with pagination details
+	err = PrintImagesInfo(images, appCtx, &util.PaginationInfo{
+		CurrentPage:   page,
+		TotalCount:    totalCount,
+		Limit:         limit,
+		NextPageToken: nextPageToken,
+	}, useJSON)
+
+	if err != nil {
+		return fmt.Errorf("printing image table: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/compute/image/get_simple_test.go
+++ b/internal/services/compute/image/get_simple_test.go
@@ -29,8 +29,7 @@ func TestListImagesSimple(t *testing.T) {
 		Stdout:          io.Discard, // Discard output to avoid cluttering the test output
 	}
 
-	err := ListImages(appCtx, 20, 1, false)
+	err := GetImages(appCtx, 20, 1, false)
 
-	// but if we did, we would expect no error
 	assert.NoError(t, err)
 }

--- a/internal/services/compute/image/list.go
+++ b/internal/services/compute/image/list.go
@@ -36,7 +36,10 @@ func ListImages(ctx context.Context, appCtx *app.ApplicationContext) error {
 		}
 	}
 
-	fmt.Println(img)
+	err = PrintImageInfo(img, appCtx)
+	if err != nil {
+		return fmt.Errorf("printing image info: %w", err)
+	}
 
 	return nil
 }

--- a/internal/services/compute/image/list.go
+++ b/internal/services/compute/image/list.go
@@ -8,6 +8,8 @@ import (
 	"github.com/rozdolsky33/ocloud/internal/app"
 )
 
+// ListImages lists all images in the given compartment, allowing the user to select one via a TUI and display its details.
+// It initializes required services, fetches images, processes user selection, and prints the chosen image information.
 func ListImages(ctx context.Context, appCtx *app.ApplicationContext) error {
 
 	service, err := NewService(appCtx)

--- a/internal/services/compute/image/list_simple_test.go
+++ b/internal/services/compute/image/list_simple_test.go
@@ -1,11 +1,12 @@
 package image
 
 import (
+	"io"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"testing"
 )
 
 // TestListImagesSimple is a simplified test for the ListImages function

--- a/internal/services/compute/image/output.go
+++ b/internal/services/compute/image/output.go
@@ -9,15 +9,12 @@ import (
 // PrintImagesInfo displays instances in a formatted table or JSON format.
 // It now returns an error to allow for proper error handling by the caller.
 func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool) error {
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}
 
-	// If JSON output is requested, use the printer to marshal the response.
 	if useJSON {
 		return util.MarshalDataToJSONResponse[Image](p, images, pagination)
 	}
@@ -26,9 +23,8 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 		return nil
 	}
 
-	// Print each image as a separate key-value table with a colored title.
+	// Print each image as a separate key-value.
 	for _, image := range images {
-		// Create image data map
 		imageData := map[string]string{
 			"Name":            image.Name,
 			"Created":         image.CreatedAt.String(),
@@ -37,15 +33,12 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 			"LunchMode":       image.LunchMode,
 		}
 
-		// Define ordered keys
 		orderedKeys := []string{
 			"Name", "Created", "ImageName", "ImageOSVersion", "OperatingSystem", "LunchMode",
 		}
 
-		// Create the colored title using components from the app context.
 		title := util.FormatColoredTitle(appCtx, image.Name)
 
-		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, imageData, orderedKeys)
 	}
 

--- a/internal/services/compute/image/output.go
+++ b/internal/services/compute/image/output.go
@@ -45,3 +45,26 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 	util.LogPaginationInfo(pagination, appCtx)
 	return nil
 }
+
+func PrintImageInfo(image Image, appCtx *app.ApplicationContext) error {
+	p := printer.New(appCtx.Stdout)
+
+	imageData := map[string]string{
+		"ID":              image.ID,
+		"Name":            image.Name,
+		"Created":         image.CreatedAt.String(),
+		"ImageOSVersion":  image.ImageOSVersion,
+		"OperatingSystem": image.OperatingSystem,
+		"LunchMode":       image.LunchMode,
+	}
+
+	orderedKeys := []string{
+		"ID", "Name", "Created", "ImageName", "ImageOSVersion", "OperatingSystem", "LunchMode",
+	}
+
+	title := util.FormatColoredTitle(appCtx, image.Name)
+
+	p.PrintKeyValues(title, imageData, orderedKeys)
+
+	return nil
+}

--- a/internal/services/compute/image/service.go
+++ b/internal/services/compute/image/service.go
@@ -27,9 +27,9 @@ func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 	}, nil
 }
 
-// List retrieves a paginated list of image with given limit and page number parameters.
+// Get retrieves a paginated list of image with given limit and page number parameters.
 // It returns the slice of image, total count, next page token, and an error if encountered.
-func (s *Service) List(ctx context.Context, limit, pageNum int) ([]Image, int, string, error) {
+func (s *Service) Get(ctx context.Context, limit, pageNum int) ([]Image, int, string, error) {
 	logger.LogWithLevel(s.logger, 3, "List() called with pagination parameters",
 		"limit", limit,
 		"pageNum", pageNum)

--- a/internal/services/compute/image/service_test.go
+++ b/internal/services/compute/image/service_test.go
@@ -1,9 +1,10 @@
 package image
 
 import (
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestServiceStruct tests the basic structure of the Service struct

--- a/internal/services/compute/image/tui_types.go
+++ b/internal/services/compute/image/tui_types.go
@@ -1,6 +1,8 @@
 package image
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -70,7 +72,7 @@ func NewImageListModelFancy(images []Image) ResourceListModel {
 	items := make([]list.Item, 0, len(images))
 	for _, img := range images {
 		name := img.Name
-		desc := img.OperatingSystem
+		desc := fmt.Sprintf("ImageOSVersion: %s", img.ImageOSVersion)
 		id := img.ID
 		items = append(items, resourceItem{id: id, title: name, description: desc})
 	}

--- a/internal/services/compute/image/tui_types.go
+++ b/internal/services/compute/image/tui_types.go
@@ -1,0 +1,78 @@
+package image
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// resourceItem defines a resource item for a list.
+type resourceItem struct {
+	id, title, description string
+}
+
+func (i resourceItem) Title() string       { return i.title }
+func (i resourceItem) Description() string { return i.description }
+func (i resourceItem) FilterValue() string { return i.title + " " + i.description }
+
+// ResourceListModel defines a TUI model for displaying a list of resources.
+type ResourceListModel struct {
+	list   list.Model
+	choice string
+	keys   struct {
+		confirm key.Binding
+		quit    key.Binding
+	}
+}
+
+func (m ResourceListModel) Init() tea.Cmd { return nil }
+func (m ResourceListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetSize(msg.Width, msg.Height-2)
+	case tea.KeyMsg:
+		if key.Matches(msg, m.keys.quit) {
+			return m, tea.Quit
+		}
+		if key.Matches(msg, m.keys.confirm) {
+			if it, ok := m.list.SelectedItem().(resourceItem); ok {
+				m.choice = it.id
+			}
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m ResourceListModel) View() string   { return m.list.View() }
+func (m ResourceListModel) Choice() string { return m.choice }
+
+func newResourceList(title string, items []list.Item) ResourceListModel {
+	delegate := list.NewDefaultDelegate()
+	l := list.New(items, delegate, 0, 0)
+	l.Title = title
+	l.SetShowTitle(true)
+	l.SetShowHelp(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowFilter(true)
+
+	rm := ResourceListModel{list: l}
+	rm.keys.confirm = key.NewBinding(key.WithKeys("enter"))
+	rm.keys.quit = key.NewBinding(key.WithKeys("q", "esc", "ctrl+c"))
+	return rm
+}
+
+// NewImageListModelFancy creates a ResourceListModel to display instances in a searchable and interactive list.
+// It transforms each instance into a resourceItem with its name, ID, and VCN name as attributes.
+func NewImageListModelFancy(images []Image) ResourceListModel {
+	items := make([]list.Item, 0, len(images))
+	for _, img := range images {
+		name := img.Name
+		desc := img.OperatingSystem
+		id := img.ID
+		items = append(items, resourceItem{id: id, title: name, description: desc})
+	}
+	return newResourceList("Images", items)
+}

--- a/internal/services/compute/instance/find.go
+++ b/internal/services/compute/instance/find.go
@@ -31,10 +31,8 @@ func FindInstances(appCtx *app.ApplicationContext, namePattern string, showImage
 	}
 
 	// TODO:
-	// Display matched instances
 	if len(matchedInstances) == 0 {
 		if useJSON {
-			// Return an empty JSON array if no instances found
 			fmt.Fprintln(appCtx.Stdout, `{"instances": [], "pagination": null}`)
 		} else {
 			fmt.Fprintf(appCtx.Stdout, "No instances found matching pattern: %s\n", namePattern)

--- a/internal/services/compute/instance/find_simple_test.go
+++ b/internal/services/compute/instance/find_simple_test.go
@@ -1,11 +1,12 @@
 package instance
 
 import (
+	"io"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"testing"
 )
 
 // TestFindInstancesSimple is a simplified test for the FindInstances function

--- a/internal/services/compute/instance/output.go
+++ b/internal/services/compute/instance/output.go
@@ -11,27 +11,22 @@ import (
 // PrintInstancesInfo displays instances in a formatted table or JSON format.
 // It now returns an error to allow for proper error handling by the caller.
 func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool, showImageDetails bool) error {
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}
 
-	// If JSON output is requested, use the printer to marshal the response.
 	if useJSON {
 		return util.MarshalDataToJSONResponse[Instance](p, instances, pagination)
 	}
 
-	// Handle the case where no instances are found.
 	if util.ValidateAndReportEmpty(instances, pagination, appCtx.Stdout) {
 		return nil
 	}
 
-	// Print each instance as a separate key-value table with a colored title.
+	// Print each instance as a separate key-value.
 	for _, instance := range instances {
-		// Create instance data map
 		instanceData := map[string]string{
 			"Shape":      instance.Shape,
 			"vCPUs":      fmt.Sprintf("%d", instance.Resources.VCPUs),
@@ -42,7 +37,6 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 			"State":      string(instance.State),
 		}
 
-		// Define ordered keys
 		orderedKeys := []string{
 			"Name", "Shape", "vCPUs", "Memory",
 			"Created", "Private IP", "State",
@@ -52,7 +46,6 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 		// Add image details if available
 		if showImageDetails {
 
-			// Add an operating system if available
 			if instance.ImageOS != "" {
 				instanceData["Operating System"] = instance.ImageOS
 			}
@@ -60,12 +53,10 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 				instanceData["Image Name"] = instance.ImageName
 			}
 
-			//Add AD
 			if instance.Placement.AvailabilityDomain != "" {
 				instanceData["AD"] = instance.Placement.AvailabilityDomain
 			}
 
-			// AD FD
 			if instance.Placement.FaultDomain != "" {
 				instanceData["FD"] = instance.Placement.FaultDomain
 			}
@@ -73,7 +64,6 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 				instanceData["Region"] = instance.Placement.Region
 			}
 
-			// Add subnet details
 			if instance.SubnetName != "" {
 				instanceData["Subnet Name"] = instance.SubnetName
 			}
@@ -82,12 +72,10 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 				instanceData["VCN Name"] = instance.VcnName
 			}
 
-			// Add hostname
 			if instance.Hostname != "" {
 				instanceData["Hostname"] = instance.Hostname
 			}
 
-			// Add private DNS enabled flag
 			instanceData["Private DNS Enabled"] = fmt.Sprintf("%t", instance.PrivateDNSEnabled)
 
 			if instance.RouteTableName != "" {
@@ -121,7 +109,6 @@ func PrintInstancesInfo(instances []Instance, appCtx *app.ApplicationContext, pa
 
 		title := util.FormatColoredTitle(appCtx, instance.Name)
 
-		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, instanceData, orderedKeys)
 	}
 

--- a/internal/services/compute/instance/service.go
+++ b/internal/services/compute/instance/service.go
@@ -49,12 +49,10 @@ func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 // If showImageDetails is true, it also enriches instances with image details.
 // Returns instances, total count, next page token, and an error, if any.
 func (s *Service) List(ctx context.Context, limit int, pageNum int, showImageDetails bool) ([]Instance, int, string, error) {
-	// Log input parameters at debug level
 	logger.LogWithLevel(s.logger, 3, "List() called with pagination parameters",
 		"limit", limit,
 		"pageNum", pageNum)
 
-	// Initialize variables
 	var instances []Instance
 	instanceMap := make(map[string]*Instance)
 	var nextPageToken string
@@ -181,9 +179,7 @@ func (s *Service) List(ctx context.Context, limit int, pageNum int, showImageDet
 	for _, oc := range resp.Items {
 		inst := mapToInstance(oc)
 		instances = append(instances, inst)
-
 		// Create a copy of the instance and store a pointer to it in the map
-		// This ensures the pointer remains valid even if the slice is reallocated
 		instanceCopy := inst
 		instanceMap[*oc.Id] = &instanceCopy
 	}
@@ -221,7 +217,7 @@ func (s *Service) List(ctx context.Context, limit int, pageNum int, showImageDet
 	// The most direct way to determine if there are more pages is to check if there's a next page token
 	hasNextPage := resp.OpcNextPage != nil
 
-	// Log detailed pagination information at debug level 1 for better visibility
+	// Log detailed pagination information at debug level
 	if hasNextPage {
 		logger.LogWithLevel(s.logger, 1, "Pagination information",
 			"currentPage", pageNum,
@@ -252,7 +248,6 @@ func (s *Service) Find(ctx context.Context, searchPattern string, showImageDetai
 	var instanceMap = make(map[string]*Instance)
 	var allInstances []Instance
 
-	// Initialize pagination variables
 	var page string
 	currentPage := 1
 
@@ -300,8 +295,6 @@ func (s *Service) Find(ctx context.Context, searchPattern string, showImageDetai
 		for _, oc := range resp.Items {
 			inst := mapToInstance(oc)
 			allInstances = append(allInstances, inst)
-
-			// Add a pointer to the instance to the map for enrichment
 			instanceCopy := inst
 			instanceMap[*oc.Id] = &instanceCopy
 		}
@@ -551,12 +544,10 @@ func (s *Service) fetchImageDetails(ctx context.Context, imageID string) (*core.
 		return nil, nil
 	}
 
-	// Create a request to get the image details
 	request := core.GetImageRequest{
 		ImageId: &imageID,
 	}
 
-	// Call the OCI API to get the image details
 	response, err := s.compute.GetImage(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("getting image details: %w", err)
@@ -568,7 +559,6 @@ func (s *Service) fetchImageDetails(ctx context.Context, imageID string) (*core.
 // enrichInstancesWithVnics enriches each instance in the provided map with its associated VNIC information.
 // This method uses a batch approach to fetch VNIC attachments for all instances at once, reducing API calls.
 func (s *Service) enrichInstancesWithVnics(ctx context.Context, instanceMap map[string]*Instance) error {
-	// Extract instance IDs
 	var instanceIDs []string
 	for id := range instanceMap {
 		instanceIDs = append(instanceIDs, id)
@@ -927,7 +917,7 @@ func (s *Service) fetchRouteTableDetails(ctx context.Context, routeTableID strin
 	return &resp.RouteTable, nil
 }
 
-// mapToInstance maps SDK Instance to local model.
+// mapToInstance maps SDK Instance to a local model.
 func mapToInstance(oc core.Instance) Instance {
 	return Instance{
 		Name: *oc.DisplayName,

--- a/internal/services/compute/instance/service_test.go
+++ b/internal/services/compute/instance/service_test.go
@@ -1,9 +1,10 @@
 package instance
 
 import (
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestServiceStruct tests the basic structure of the Service struct

--- a/internal/services/compute/oke/find.go
+++ b/internal/services/compute/oke/find.go
@@ -22,10 +22,8 @@ func FindClusters(appCtx *app.ApplicationContext, namePattern string, useJSON bo
 		return fmt.Errorf("finding oke clusters: %w", err)
 	}
 
-	// Display matched clusters
 	if len(clusters) == 0 {
 		if useJSON {
-			// Return an empty JSON array if no clusters found
 			fmt.Fprintln(appCtx.Stdout, `{"clusters": []}`)
 		} else {
 			fmt.Fprintf(appCtx.Stdout, "No clusters found matching pattern: %s\n", namePattern)

--- a/internal/services/compute/oke/find_test.go
+++ b/internal/services/compute/oke/find_test.go
@@ -2,10 +2,11 @@ package oke
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestFindClusters tests the FindClusters function
@@ -15,11 +16,11 @@ func TestFindClusters(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindClusters function
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call FindClusters with different search patterns
 	// 3. Verify that the output contains the expected information
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -47,11 +48,11 @@ func TestFindClustersWithJSON(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindClusters function with JSON output
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call FindClusters with different search patterns and useJSON=true
 	// 3. Verify that the output is valid JSON and contains the expected information
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -79,11 +80,11 @@ func TestFindClustersError(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindClusters function with an error
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Set up the mock to return an error
 	// 3. Call FindClusters and verify that it returns the expected error
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/compute/oke/kubeconfig.go
+++ b/internal/services/compute/oke/kubeconfig.go
@@ -9,11 +9,10 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	util "github.com/rozdolsky33/ocloud/internal/services/util"
+	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
 // kubeconfig model (unexported)
-
 type kubeConfig struct {
 	APIVersion     string         `yaml:"apiVersion"`
 	Kind           string         `yaml:"kind"`
@@ -23,26 +22,31 @@ type kubeConfig struct {
 	CurrentContext string         `yaml:"current-context"`
 }
 
+// namedCluster represents a named Kubernetes cluster configuration consisting of a name and its corresponding details.
 type namedCluster struct {
 	Name    string    `yaml:"name"`
 	Cluster kcCluster `yaml:"cluster"`
 }
 
+// kcCluster represents a Kubernetes cluster configuration consisting of a server address and certificate details.
 type kcCluster struct {
 	Server                   string `yaml:"server"`
 	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
 	InsecureSkipTLSVerify    bool   `yaml:"insecure-skip-tls-verify,omitempty"`
 }
 
+// namedUser represents a named Kubernetes user configuration consisting of a name and its corresponding details.
 type namedUser struct {
 	Name string `yaml:"name"`
 	User kcUser `yaml:"user"`
 }
 
+// kcUser represents a Kubernetes user configuration.
 type kcUser struct {
 	Exec *kcExec `yaml:"exec,omitempty"`
 }
 
+// kcExec represents a Kubernetes exec configuration.
 type kcExec struct {
 	APIVersion         string   `yaml:"apiVersion"`
 	Command            string   `yaml:"command"`
@@ -52,11 +56,13 @@ type kcExec struct {
 	ProvideClusterInfo bool     `yaml:"provideClusterInfo"`
 }
 
+// namedContext represents a named Kubernetes context configuration consisting of a name and its corresponding details.
 type namedContext struct {
 	Name    string    `yaml:"name"`
 	Context kcContext `yaml:"context"`
 }
 
+// kcContext represents Kubernetes context details including cluster, namespace, and user mappings.
 type kcContext struct {
 	Cluster   string `yaml:"cluster"`
 	Namespace string `yaml:"namespace"`
@@ -110,7 +116,6 @@ func EnsureKubeconfigForOKE(cluster Cluster, region, profile string, localPort i
 		return nil
 	}
 
-	// Ask a user if they want a custom context name
 	if util.PromptYesNo(fmt.Sprintf("Do you want to enter a custom kube context name for this cluster? (Default is '%s')", ctxName)) {
 		if name, err := util.PromptString("Enter kube context name", ctxName); err == nil {
 			name = strings.TrimSpace(name)
@@ -155,8 +160,7 @@ func EnsureKubeconfigForOKE(cluster Cluster, region, profile string, localPort i
 		kc.CurrentContext = ctxName
 	}
 
-	// Prepare YAML with explicit 2-space indentation for consistency
-	// and write atomically to the target file.
+	// write atomically to the target file.
 	// Backup if exists first.
 	if _, err := os.Stat(cfgPath); err == nil {
 		if old, err := os.ReadFile(cfgPath); err == nil {
@@ -183,6 +187,7 @@ func EnsureKubeconfigForOKE(cluster Cluster, region, profile string, localPort i
 	return nil
 }
 
+// shortID returns a shortened version of the given cluster id.
 func shortID(id string) string {
 	// Try to take suffix after the last '.' or '/'
 	s := id
@@ -198,6 +203,7 @@ func shortID(id string) string {
 	return s
 }
 
+// hasNamed returns true if the given array contains an element satisfying the given predicate.
 func hasNamed[T any](arr []T, pred func(T) bool) bool {
 	for _, v := range arr {
 		if pred(v) {
@@ -207,6 +213,7 @@ func hasNamed[T any](arr []T, pred func(T) bool) bool {
 	return false
 }
 
+// upsert* functions are used to upsert an element into an array of named elements.
 func upsertCluster(arr []namedCluster, item namedCluster) []namedCluster {
 	for i, v := range arr {
 		if v.Name == item.Name {
@@ -217,6 +224,7 @@ func upsertCluster(arr []namedCluster, item namedCluster) []namedCluster {
 	return append(arr, item)
 }
 
+// upsert* functions are used to upsert an element into an array of named elements.
 func upsertUser(arr []namedUser, item namedUser) []namedUser {
 	for i, v := range arr {
 		if v.Name == item.Name {
@@ -227,6 +235,7 @@ func upsertUser(arr []namedUser, item namedUser) []namedUser {
 	return append(arr, item)
 }
 
+// upsert* functions are used to upsert an element into an array of named elements.
 func upsertContext(arr []namedContext, item namedContext) []namedContext {
 	for i, v := range arr {
 		if v.Name == item.Name {
@@ -243,7 +252,6 @@ func matchOKEExec(exec *kcExec, clusterID, region, profile string) bool {
 	if exec == nil {
 		return false
 	}
-	// We expect the command to be `oci` and args to contain ce cluster generate-token
 	if exec.Command != "oci" {
 		return false
 	}

--- a/internal/services/compute/oke/list_test.go
+++ b/internal/services/compute/oke/list_test.go
@@ -2,10 +2,11 @@ package oke
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestListClusters tests the ListClusters function
@@ -15,11 +16,11 @@ func TestListClusters(t *testing.T) {
 
 	// This is a placeholder test that would normally test the ListClusters function
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call ListClusters with different parameters
 	// 3. Verify that the output contains the expected information
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/compute/oke/output.go
+++ b/internal/services/compute/oke/output.go
@@ -73,12 +73,7 @@ func PrintOKETable(clusters []Cluster, appCtx *app.ApplicationContext, paginatio
 }
 
 // PrintOKEInfo prints a detailed, troubleshooting‑oriented view of OKE clusters
-// and their node pools.  Each cluster is rendered as:
-//  1. A summary key/value block containing operationally‑relevant metadata.
-//  2. A responsive table listing all node pools with the most useful columns
-//     for SRE triage.
-//
-// When --JSON is requested, the function defers to util.MarshalDataToJSONResponse.
+// and their node pools.
 func PrintOKEInfo(clusters []Cluster, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool) error {
 	p := printer.New(appCtx.Stdout)
 

--- a/internal/services/compute/oke/output_test.go
+++ b/internal/services/compute/oke/output_test.go
@@ -2,11 +2,12 @@ package oke
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestPrintOKETable tests the PrintOKETable function

--- a/internal/services/compute/oke/types.go
+++ b/internal/services/compute/oke/types.go
@@ -6,12 +6,15 @@ import (
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
+// Service encapsulates OCI container engine clients and configuration.
+// It provides methods to list and find clusters without printing directly.
 type Service struct {
 	containerEngineClient containerengine.ContainerEngineClient
 	logger                logr.Logger
 	compartmentID         string
 }
 
+// Cluster represents an OKE cluster with its attributes and connection details.
 type Cluster struct {
 	Name               string
 	ID                 string
@@ -25,6 +28,7 @@ type Cluster struct {
 	OKETags            util.ResourceTags
 }
 
+// NodePool represents an OKE node pool with its attributes.
 type NodePool struct {
 	Name      string
 	ID        string
@@ -38,6 +42,7 @@ type NodePool struct {
 	NodeTags  util.ResourceTags
 }
 
+// JSONResponse represents the JSON response from the OKE API.
 type JSONResponse struct {
 	Clusters []Cluster `json:"clusters"`
 }

--- a/internal/services/configuration/auth/authenticate.go
+++ b/internal/services/configuration/auth/authenticate.go
@@ -9,7 +9,6 @@ import (
 
 // AuthenticateWithOCI handles the authentication process with Oracle Cloud Infrastructure (OCI) using interactive inputs.
 // It performs authentication with the provided filter and realm, displays environment variables, and optionally starts the auth refresher.
-// Returns an error if any step in the process fails.
 func AuthenticateWithOCI(filter, realm string) error {
 
 	s := NewService()
@@ -23,11 +22,6 @@ func AuthenticateWithOCI(filter, realm string) error {
 
 	logger.LogWithLevel(s.logger, 3, "Interactive authentication completed", "tenancyID", result.TenancyID, "tenancyName", result.TenancyName)
 
-	logger.LogWithLevel(s.logger, 3, "Displaying environment variables")
-	if err = PrintExportVariable(result.Profile, result.TenancyName, result.CompartmentName); err != nil {
-		return fmt.Errorf("printing export variables: %w", err)
-	}
-
 	logger.LogWithLevel(s.logger, 1, "Authentication process completed successfully")
 
 	logger.LogWithLevel(s.logger, 1, "Starting OCI auth refresher for profile", "profile", result.Profile)
@@ -39,6 +33,11 @@ func AuthenticateWithOCI(filter, realm string) error {
 		logger.LogWithLevel(s.logger, 1, "OCI auth refresher enabled")
 	} else {
 		logger.LogWithLevel(s.logger, 1, "OCI auth refresher disabled")
+	}
+
+	logger.LogWithLevel(s.logger, 3, "Displaying environment variables")
+	if err = PrintExportVariable(result.Profile, result.TenancyName, result.CompartmentName); err != nil {
+		return fmt.Errorf("printing export variables: %w", err)
 	}
 
 	return nil

--- a/internal/services/configuration/auth/output.go
+++ b/internal/services/configuration/auth/output.go
@@ -111,7 +111,6 @@ func getRegionGroupTitle(prefix string) string {
 func PrintExportVariable(profile, tenancyName, compartment string) error {
 	logger.LogWithLevel(logger.Logger, 3, "Printing export variables", "profile", profile, "tenancyName", tenancyName, "compartment", compartment)
 
-	// Create a map of environment variables to export
 	exportVars := make(map[string]string)
 
 	if profile != "" {

--- a/internal/services/configuration/info/output.go
+++ b/internal/services/configuration/info/output.go
@@ -13,7 +13,6 @@ import (
 
 // PrintMappingsFile displays tenancy mapping information in a formatted table or JSON format.
 // It takes a slice of MappingsFile, the application context, and a boolean indicating whether to use JSON format.
-// Returns an error if the display operation fails.
 func PrintMappingsFile(mappings []appConfig.MappingsFile, useJSON bool) error {
 
 	p := printer.New(os.Stdout)
@@ -89,13 +88,10 @@ func PrintMappingsFile(mappings []appConfig.MappingsFile, useJSON bool) error {
 }
 
 // groupMappingsByRealm groups mappings by their realm.
-// It returns a map where the key is the realm and the value is a slice of mappings for that realm.
 func groupMappingsByRealm(mappings []appConfig.MappingsFile) map[string][]appConfig.MappingsFile {
 	realmGroups := make(map[string][]appConfig.MappingsFile)
-
 	for _, mapping := range mappings {
 		realmGroups[mapping.Realm] = append(realmGroups[mapping.Realm], mapping)
 	}
-
 	return realmGroups
 }

--- a/internal/services/configuration/info/service.go
+++ b/internal/services/configuration/info/service.go
@@ -21,7 +21,6 @@ func NewService() *Service {
 }
 
 // LoadTenancyMappings loads the tenancy mappings from the file and filters them by realm if specified.
-// It returns a TenancyMappingResult containing the filtered mappings and an error if encountered.
 func (s *Service) LoadTenancyMappings(realm string) (*TenancyMappingResult, error) {
 	// Load the tenancy mapping from the file
 	logger.LogWithLevel(s.logger, 3, "Loading tenancy mappings", "realm", realm)

--- a/internal/services/configuration/setup/service.go
+++ b/internal/services/configuration/setup/service.go
@@ -16,7 +16,6 @@ import (
 )
 
 // NewService initializes a new Service instance with the provided application context.
-// Returns a Service pointer.
 func NewService() *Service {
 	appCtx := &app.ApplicationContext{
 		Logger: logger.Logger,

--- a/internal/services/database/autonomousdb/find.go
+++ b/internal/services/database/autonomousdb/find.go
@@ -10,7 +10,6 @@ import (
 
 // FindAutonomousDatabases searches for Autonomous Databases matching the provided name pattern in the application context.
 // Logs database discovery tasks and can format the result based on the useJSON flag.
-// Returns an error if the discovery or result formatting fails.
 func FindAutonomousDatabases(appCtx *app.ApplicationContext, namePattern string, useJSON bool) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Finding Autonomous Databases", "pattern", namePattern)
 

--- a/internal/services/database/autonomousdb/find_test.go
+++ b/internal/services/database/autonomousdb/find_test.go
@@ -1,11 +1,12 @@
 package autonomousdb
 
 import (
+	"io"
+	"testing"
+
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"testing"
 )
 
 // TestFindAutonomousDatabaseSimple is a simplified test for the FindAutonomousDatabases function

--- a/internal/services/database/autonomousdb/list.go
+++ b/internal/services/database/autonomousdb/list.go
@@ -12,7 +12,6 @@ import (
 // ListAutonomousDatabase fetches and lists all autonomous databases within a specified application context.
 // appCtx represents the application context containing configuration and client details.
 // useJSON if true, outputs the list of databases in JSON format; otherwise, uses a plain-text format.
-// Returns an error if the operation fails.
 func ListAutonomousDatabase(appCtx *app.ApplicationContext, useJSON bool, limit, page int) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Listing Autonomous Databases")
 

--- a/internal/services/database/autonomousdb/service.go
+++ b/internal/services/database/autonomousdb/service.go
@@ -13,7 +13,6 @@ import (
 )
 
 // NewService initializes a new Service instance with the provided application context.
-// Returns a Service pointer and an error if initialization fails.
 func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 	cfg := appCtx.Provider
 	dbClient, err := oci.NewDatabaseClient(cfg)

--- a/internal/services/identity/bastion/list.go
+++ b/internal/services/identity/bastion/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rozdolsky33/ocloud/internal/logger"
 )
 
+// ListBastions retrieves a list of bastion hosts and displays their information, optionally in JSON format.
 func ListBastions(ctx context.Context, appCtx *app.ApplicationContext, useJSON bool) error {
 
 	logger.LogWithLevel(appCtx.Logger, 1, "Listing bastions")

--- a/internal/services/identity/bastion/output.go
+++ b/internal/services/identity/bastion/output.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
+// PrintBastionInfo displays bastion instances in a formatted table or JSON format.
 func PrintBastionInfo(bastions []Bastion, appCtx *app.ApplicationContext, useJSON bool) error {
 
 	p := printer.New(appCtx.Stdout)

--- a/internal/services/identity/bastion/output.go
+++ b/internal/services/identity/bastion/output.go
@@ -8,7 +8,6 @@ import (
 
 func PrintBastionInfo(bastions []Bastion, appCtx *app.ApplicationContext, useJSON bool) error {
 
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 	if useJSON {
 		if len(bastions) == 0 {
@@ -25,14 +24,13 @@ func PrintBastionInfo(bastions []Bastion, appCtx *app.ApplicationContext, useJSO
 			"TargetVcn":      b.TargetVcnName,
 			"TargetSubnet":   b.TargetSubnetName,
 		}
-		// Define ordered Keys
+
 		orderedKeys := []string{
 			"Name", "BastionType", "LifecycleState", "TargetVcn", "TargetSubnet",
 		}
 
 		title := util.FormatColoredTitle(appCtx, b.Name)
 
-		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, bastionInfo, orderedKeys)
 	}
 

--- a/internal/services/identity/bastion/reachability.go
+++ b/internal/services/identity/bastion/reachability.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/rozdolsky33/ocloud/internal/services/compute/instance"
 )
 
 // CanReach checks if the provided bastion can reach a target identified by target VCN and/or Subnet.
@@ -43,29 +44,52 @@ func (s *Service) CanReach(ctx context.Context, b Bastion, targetVcnID string, t
 
 // IsBastionAgentPluginEnabled checks if the "Bastion" agent plugin is enabled for the given instance ID. Returns a boolean and error.
 func (s *Service) IsBastionAgentPluginEnabled(ctx context.Context, instanceID string) (bool, error) {
+
 	if instanceID == "" {
 		return false, fmt.Errorf("instance ID is empty")
 	}
+
 	resp, err := s.computeClient.GetInstance(ctx, core.GetInstanceRequest{InstanceId: &instanceID})
 	if err != nil {
 		return false, fmt.Errorf("failed to get instance: %w", err)
 	}
+
 	if resp.Instance.AgentConfig == nil {
 		return false, fmt.Errorf("instance agent configuration is not available")
 	}
-	plugins := resp.Instance.AgentConfig.PluginsConfig
-	if len(plugins) == 0 {
-		return false, fmt.Errorf("instance agent plugin configuration is not available")
-	}
-	for _, p := range plugins {
+
+	for _, p := range resp.Instance.AgentConfig.PluginsConfig {
 		if p.Name != nil && *p.Name == "Bastion" {
 			if p.DesiredState == core.InstanceAgentPluginConfigDetailsDesiredStateEnabled {
-				return true, fmt.Errorf("instance agent plugin 'Bastion' is enabled")
+				return true, nil
 			}
-			return false, fmt.Errorf("instance agent plugin 'Bastion' is disabled")
+			return false, fmt.Errorf("bastion agent plugin is disabled")
 		}
 	}
-	return false, fmt.Errorf("instance agent plugin 'Bastion' is not configured")
+
+	return false, fmt.Errorf("bastion agent plugin is not configured")
+}
+
+// FilterInstancesWithBastionEnabled filters []Instance slice
+// and returns only those with the Bastion agent plugin enabled.
+func (s *Service) FilterInstancesWithBastionEnabled(ctx context.Context, instances []instance.Instance) ([]instance.Instance, error) {
+	var result []instance.Instance
+
+	for _, inst := range instances {
+		if inst.ID == "" {
+			continue
+		}
+		ok, err := s.IsBastionAgentPluginEnabled(ctx, inst.ID)
+		if err != nil {
+			continue
+		}
+
+		if ok {
+			result = append(result, inst)
+		}
+	}
+
+	return result, nil
 }
 
 // vcnMatches checks if the provided subnet's VCN ID matches the specified bastion VCN ID. Returns true if they match.

--- a/internal/services/identity/bastion/reachability.go
+++ b/internal/services/identity/bastion/reachability.go
@@ -12,13 +12,11 @@ import (
 // - If targetSubnetID is provided, we fetch it and compare its VCN ID with bastion.TargetVcnId.
 // - Else if targetVcnID is provided, we compare it directly with bastion.TargetVcnId.
 // - If neither targetVcnID nor targetSubnetID is provided, we cannot determine reachability.
-// Returns ok boolean and a user-friendly reason string.
 func (s *Service) CanReach(ctx context.Context, b Bastion, targetVcnID string, targetSubnetID string) (bool, string) {
 	if b.TargetVcnId == "" {
 		return false, "Selected Bastion is not configured with a target VCN."
 	}
 
-	// Prefer subnet if provided to derive VCN and be precise.
 	if targetSubnetID != "" {
 		subnet, err := s.fetchSubnetDetails(ctx, targetSubnetID)
 		if err != nil {

--- a/internal/services/identity/bastion/reachability.go
+++ b/internal/services/identity/bastion/reachability.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v65/core"
-	"github.com/rozdolsky33/ocloud/internal/services/compute/instance"
 )
 
 // CanReach checks if the provided bastion can reach a target identified by target VCN and/or Subnet.
@@ -40,56 +39,6 @@ func (s *Service) CanReach(ctx context.Context, b Bastion, targetVcnID string, t
 	}
 
 	return false, "Target network details are unavailable; cannot verify reachability."
-}
-
-// IsBastionAgentPluginEnabled checks if the "Bastion" agent plugin is enabled for the given instance ID. Returns a boolean and error.
-func (s *Service) IsBastionAgentPluginEnabled(ctx context.Context, instanceID string) (bool, error) {
-
-	if instanceID == "" {
-		return false, fmt.Errorf("instance ID is empty")
-	}
-
-	resp, err := s.computeClient.GetInstance(ctx, core.GetInstanceRequest{InstanceId: &instanceID})
-	if err != nil {
-		return false, fmt.Errorf("failed to get instance: %w", err)
-	}
-
-	if resp.Instance.AgentConfig == nil {
-		return false, fmt.Errorf("instance agent configuration is not available")
-	}
-
-	for _, p := range resp.Instance.AgentConfig.PluginsConfig {
-		if p.Name != nil && *p.Name == "Bastion" {
-			if p.DesiredState == core.InstanceAgentPluginConfigDetailsDesiredStateEnabled {
-				return true, nil
-			}
-			return false, fmt.Errorf("bastion agent plugin is disabled")
-		}
-	}
-
-	return false, fmt.Errorf("bastion agent plugin is not configured")
-}
-
-// FilterInstancesWithBastionEnabled filters []Instance slice
-// and returns only those with the Bastion agent plugin enabled.
-func (s *Service) FilterInstancesWithBastionEnabled(ctx context.Context, instances []instance.Instance) ([]instance.Instance, error) {
-	var result []instance.Instance
-
-	for _, inst := range instances {
-		if inst.ID == "" {
-			continue
-		}
-		ok, err := s.IsBastionAgentPluginEnabled(ctx, inst.ID)
-		if err != nil {
-			continue
-		}
-
-		if ok {
-			result = append(result, inst)
-		}
-	}
-
-	return result, nil
 }
 
 // vcnMatches checks if the provided subnet's VCN ID matches the specified bastion VCN ID. Returns true if they match.

--- a/internal/services/identity/bastion/session.go
+++ b/internal/services/identity/bastion/session.go
@@ -284,7 +284,7 @@ func SpawnDetached(args []string, logfile string) (int, error) {
 }
 
 // WaitForListen wait until the localPort is listening (nice UX).
-// This is not strictly necessary, but it helps to avoid "connection refused" errors.
+// Helps to avoid "connection refused" errors.
 func WaitForListen(localPort int, timeout time.Duration) error {
 	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
 	deadline := time.Now().Add(timeout)

--- a/internal/services/identity/bastion/types.go
+++ b/internal/services/identity/bastion/types.go
@@ -1,13 +1,9 @@
 package bastion
 
 import (
-	"path/filepath"
-
 	"github.com/go-logr/logr"
 	"github.com/oracle/oci-go-sdk/v65/bastion"
 	"github.com/oracle/oci-go-sdk/v65/core"
-	conf "github.com/rozdolsky33/ocloud/internal/config"
-	cflags "github.com/rozdolsky33/ocloud/internal/config/flags"
 )
 
 // Bastion represents a bastion host in the system
@@ -37,27 +33,4 @@ type Config struct {
 	SshPublicKeyFile  string `yaml:"ssh_pub_key_file"`
 	SshPrivateKeyFile string `yaml:"ssh_private_key_file"`
 	SessionTimeout    *int   `yaml:"session_timeout"`
-}
-
-// sshConfig populates default values for SSH key locations based on the active OCI profile.
-// It dynamically constructs the path to the OCI session directory using standard constants.
-// The generated default points to the per-profile OCI session directory under:
-//
-//	<home>/.oci/sessions/<PROFILE>
-//
-// By default, it selects the standard OCI key filenames inside that directory:
-//   - oci_api_key_public.pem (public)
-//   - oci_api_key.pem (private)
-func (config *Config) sshConfig() {
-	homeDir, _ := conf.GetUserHomeDir()
-	profile := conf.GetOCIProfile()
-	// Build session directory: ~/.oci/sessions/<profile>
-	sessionDir := filepath.Join(homeDir, cflags.OCIConfigDirName, cflags.OCISessionsDirName, profile)
-
-	if config.SshPublicKeyFile == "" {
-		config.SshPublicKeyFile = filepath.Join(sessionDir, "oci_api_key_public.pem")
-	}
-	if config.SshPrivateKeyFile == "" {
-		config.SshPrivateKeyFile = filepath.Join(sessionDir, "oci_api_key.pem")
-	}
 }

--- a/internal/services/identity/bastion/types.go
+++ b/internal/services/identity/bastion/types.go
@@ -29,6 +29,7 @@ type Service struct {
 	subnetCache   map[string]*core.Subnet
 }
 
+// Config represents the configuration for the bastion service.
 type Config struct {
 	SshPublicKeyFile  string `yaml:"ssh_pub_key_file"`
 	SshPrivateKeyFile string `yaml:"ssh_private_key_file"`

--- a/internal/services/identity/compartment/find.go
+++ b/internal/services/identity/compartment/find.go
@@ -10,7 +10,6 @@ import (
 
 // FindCompartments searches and displays compartments matching a given name pattern with optional JSON formatting.
 // It initializes necessary services, performs a fuzzy search, and outputs results using the defined application context.
-// Returns an error if service initialization, search, or result rendering fails.
 func FindCompartments(appCtx *app.ApplicationContext, namePattern string, useJSON bool) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Finding Compartments", "pattern", namePattern)
 

--- a/internal/services/identity/compartment/list.go
+++ b/internal/services/identity/compartment/list.go
@@ -11,7 +11,6 @@ import (
 
 // ListCompartments retrieves and displays a paginated list of compartments for the given application context.
 // It uses the provided limit, page number, and output format (JSON or table) to render the results.
-// Returns an error if fetching or displaying compartments fails.
 func ListCompartments(appCtx *app.ApplicationContext, useJSON bool, limit, page int) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Listing Compartments", "limit", limit, "page", page)
 

--- a/internal/services/identity/compartment/output.go
+++ b/internal/services/identity/compartment/output.go
@@ -9,11 +9,8 @@ import (
 // PrintCompartmentsTable displays a table or JSON representation of compartments based on the provided configuration.
 // It optionally includes pagination details and writes to the application's standard output or as structured JSON.
 func PrintCompartmentsTable(compartments []Compartment, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool) error {
-
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}
@@ -56,13 +53,10 @@ func PrintCompartmentsTable(compartments []Compartment, appCtx *app.ApplicationC
 // PrintCompartmentsInfo displays information about a list of compartments in either JSON or formatted table output.
 // It accepts a slice of Compartment, application context, pagination info, and a boolean to indicate JSON output.
 // It adjusts pagination details, validates empty compartments, and logs pagination info post-output.
-// Returns an error if JSON marshalling or output rendering fails.
 func PrintCompartmentsInfo(compartments []Compartment, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool) error {
 
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}
@@ -80,7 +74,7 @@ func PrintCompartmentsInfo(compartments []Compartment, appCtx *app.ApplicationCo
 		return nil
 	}
 
-	// Print each Compartment as a separate key-value table with a colored title.
+	// Print each Compartment as a separate key-value.
 	for _, compartment := range compartments {
 		compartmentData := map[string]string{
 			"Name":        compartment.Name,
@@ -94,7 +88,6 @@ func PrintCompartmentsInfo(compartments []Compartment, appCtx *app.ApplicationCo
 
 		title := util.FormatColoredTitle(appCtx, compartment.Name)
 
-		// Call the printer method to render the key-value table for this instance.
 		p.PrintKeyValues(title, compartmentData, orderedKeys)
 	}
 

--- a/internal/services/identity/compartment/service.go
+++ b/internal/services/identity/compartment/service.go
@@ -30,8 +30,6 @@ func (s *Service) List(ctx context.Context, limit, pageNum int) ([]Compartment, 
 	var totalCount int
 	logger.LogWithLevel(s.logger, 3, "List compartments", "limit", limit, "pageNum", pageNum, "Total Count", totalCount)
 
-	// Prepare the base request
-	// to Create a request with a limit parameter to fetch only the required page
 	request := identity.ListCompartmentsRequest{
 		CompartmentId:          &s.TenancyID,
 		AccessLevel:            identity.ListCompartmentsAccessLevelAccessible,

--- a/internal/services/identity/policy/find.go
+++ b/internal/services/identity/policy/find.go
@@ -12,7 +12,6 @@ import (
 // appCtx represents the application context with the necessary clients and configurations.
 // namePattern specifies the pattern to filter policy names.
 // useJSON determines whether the output should be formatted as JSON.
-// Returns an error if policy retrieval or processing fails.
 func FindPolicies(appCtx *app.ApplicationContext, namePattern string, useJSON bool) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Finding Policies", "pattern", namePattern)
 

--- a/internal/services/identity/policy/output.go
+++ b/internal/services/identity/policy/output.go
@@ -7,13 +7,11 @@ import (
 )
 
 // PrintPolicyInfo prints the details of policies to the standard output or in JSON format.
-// If pagination info is provided, it adjusts and logs it. Returns an error if JSON marshaling fails.
+// If pagination info is provided, it adjusts and logs it.
 func PrintPolicyInfo(policies []Policy, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool) error {
 
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}

--- a/internal/services/identity/policy/service.go
+++ b/internal/services/identity/policy/service.go
@@ -12,7 +12,6 @@ import (
 )
 
 // NewService initializes a new Service instance with the provided application context.
-// Returns a Service pointer and an error if initialization fails.
 func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 	return &Service{
 		identityClient: appCtx.IdentityClient,
@@ -30,7 +29,6 @@ func (s *Service) List(ctx context.Context, limit, pageNum int) ([]Policy, int, 
 	var totalCount int
 
 	// Prepare the base request
-	// Create a request with a limited parameter to fetch only the required page
 	request := identity.ListPoliciesRequest{
 		CompartmentId: &s.CompartmentID,
 	}

--- a/internal/services/network/subnet/find_test.go
+++ b/internal/services/network/subnet/find_test.go
@@ -16,11 +16,11 @@ func TestFindSubnets(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindSubnets function
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call FindSubnets with different search patterns
 	// 3. Verify that the output contains the expected information
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -48,11 +48,11 @@ func TestFindSubnetsWithJSON(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindSubnets function with JSON output
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call FindSubnets with different search patterns and useJSON=true
 	// 3. Verify that the output is valid JSON and contains the expected information
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -80,11 +80,11 @@ func TestFindSubnetsError(t *testing.T) {
 
 	// This is a placeholder test that would normally test the FindSubnets function with an error
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Set up the mock to return an error
 	// 3. Call FindSubnets and verify that it returns the expected error
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/network/subnet/list.go
+++ b/internal/services/network/subnet/list.go
@@ -11,7 +11,6 @@ import (
 
 // ListSubnets retrieves and displays a list of subnets, utilizing pagination, sorting, and optional JSON output.
 // Parameters include an application context, a flag for JSON output, limit, page number, and a sorting key.
-// Returns an error if any issue occurs during retrieval or output generation.
 func ListSubnets(appCtx *app.ApplicationContext, useJSON bool, limit, page int, sortBy string) error {
 	logger.LogWithLevel(appCtx.Logger, 1, "Listing Subnets", "limit", limit, "page", page, "sortBy", sortBy)
 

--- a/internal/services/network/subnet/list_test.go
+++ b/internal/services/network/subnet/list_test.go
@@ -80,11 +80,11 @@ func TestListSubnetsWithPagination(t *testing.T) {
 
 	// This is a placeholder test that would normally test the ListSubnets function with pagination
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
-	// 2. Call ListSubnets with different limit and page parameters
+	// 1. Create a mock application context with mock stdout
+	// 2. Call ListSubnets with different limits and page parameters
 	// 3. Verify that the output contains the expected information and pagination details
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -113,11 +113,11 @@ func TestListSubnetsWithSorting(t *testing.T) {
 
 	// This is a placeholder test that would normally test the ListSubnets function with sorting
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Call ListSubnets with different sortBy parameters
 	// 3. Verify that the output contains the subnets in the expected order
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout
@@ -145,11 +145,11 @@ func TestListSubnetsError(t *testing.T) {
 
 	// This is a placeholder test that would normally test the ListSubnets function with an error
 	// In a real test, we would:
-	// 1. Create a mock application context with a mock stdout
+	// 1. Create a mock application context with mock stdout
 	// 2. Set up the mock to return an error
 	// 3. Call ListSubnets and verify that it returns the expected error
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/network/subnet/output.go
+++ b/internal/services/network/subnet/output.go
@@ -11,13 +11,9 @@ import (
 
 // PrintSubnetTable displays a table of subnets with details such as name, CIDR, and DNS info.
 // Supports JSON output, pagination, and sorting by specified fields.
-// Returns an error if data marshaling or printing fails.
 func PrintSubnetTable(subnets []Subnet, appCtx *app.ApplicationContext, pagination *util.PaginationInfo, useJSON bool, sortBy string) error {
-
-	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
 
-	// Adjust the pagination information if available
 	if pagination != nil {
 		util.AdjustPaginationInfo(pagination)
 	}
@@ -85,7 +81,6 @@ func PrintSubnetTable(subnets []Subnet, appCtx *app.ApplicationContext, paginati
 // - subnets: A slice of Subnet structs containing data to display.
 // - appCtx: A pointer to the application context, used for output and configuration.
 // - useJSON: A boolean indicating whether the output should be in JSON format.
-// Returns an error if JSON marshaling or other operations fail.
 func PrintSubnetInfo(subnets []Subnet, appCtx *app.ApplicationContext, useJSON bool) error {
 	// Create a new printer that writes to the application's standard output.
 	p := printer.New(appCtx.Stdout)
@@ -99,7 +94,7 @@ func PrintSubnetInfo(subnets []Subnet, appCtx *app.ApplicationContext, useJSON b
 		return nil
 	}
 
-	// Print each policy as a separate key-value table with a colored title,
+	// Print each policy as a separate key-value.
 	for _, subnet := range subnets {
 		publicIPAllowed := "No"
 		if !subnet.ProhibitPublicIPOnVnic {
@@ -113,7 +108,6 @@ func PrintSubnetInfo(subnets []Subnet, appCtx *app.ApplicationContext, useJSON b
 			"Subnet Domain": subnet.SubnetDomainName,
 		}
 
-		// Define ordered keys
 		orderedKeys := []string{
 			"Name", "Public IP", "CIDR", "DNS Label", "Subnet Domain",
 		}
@@ -121,7 +115,6 @@ func PrintSubnetInfo(subnets []Subnet, appCtx *app.ApplicationContext, useJSON b
 		// Create the colored title using components from the app context
 		title := util.FormatColoredTitle(appCtx, subnet.Name)
 
-		// Call the printer method to render the key-value from the app context.
 		p.PrintKeyValues(title, subnetData, orderedKeys)
 	}
 

--- a/internal/services/network/subnet/output_test.go
+++ b/internal/services/network/subnet/output_test.go
@@ -82,7 +82,7 @@ func TestPrintSubnetTableEmpty(t *testing.T) {
 	// Create an empty subnets slice
 	subnets := []Subnet{}
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/network/subnet/output_test.go
+++ b/internal/services/network/subnet/output_test.go
@@ -191,7 +191,7 @@ func TestPrintSubnetInfo(t *testing.T) {
 		},
 	}
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/network/subnet/service.go
+++ b/internal/services/network/subnet/service.go
@@ -13,7 +13,6 @@ import (
 )
 
 // NewService creates and initializes a new Service instance using the provided application context.
-// It returns the created Service or an error if initialization fails.
 func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 	cfg := appCtx.Provider
 	nc, err := oci.NewNetworkClient(cfg)
@@ -36,7 +35,6 @@ func (s *Service) List(ctx context.Context, limit int, pageNum int) ([]Subnet, i
 	var totalCount int
 
 	// Prepare the base request
-	// Create a request with limited parameters to fetch only the required page
 	request := core.ListSubnetsRequest{
 		CompartmentId: &s.compartmentID,
 	}

--- a/internal/services/util/helpers.go
+++ b/internal/services/util/helpers.go
@@ -104,7 +104,6 @@ func DefaultPublicSSHKey() []string {
 			continue
 		}
 		name := f.Name()
-		// Only show public keys by default
 		if strings.HasSuffix(name, ".pub") {
 			sshKeys = append(sshKeys, filepath.Join(sshDir, name))
 		}

--- a/internal/services/util/helpers.go
+++ b/internal/services/util/helpers.go
@@ -84,6 +84,7 @@ func ShowConstructionAnimation() {
 	fmt.Println("🚧 This feature is not implemented yet. Coming soon!")
 }
 
+// DefaultPublicSSHKey returns full paths to public SSH keys under ~/.ssh (only .pub files).
 func DefaultPublicSSHKey() []string {
 	// Return full paths to public SSH keys under ~/.ssh so the picker can be used directly.
 	sshKeys := make([]string, 0)

--- a/internal/services/util/netutil.go
+++ b/internal/services/util/netutil.go
@@ -1,5 +1,5 @@
 // Package bastion Network-related utilities (hostname extraction and ctx-aware DNS).
-package bastion
+package util
 
 import (
 	"context"
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-// extractHostname removes schema/port/path and returns just the host portion.
-func extractHostname(endpoint string) string {
+// ExtractHostname removes schema/port/path and returns just the host portion.
+func ExtractHostname(endpoint string) string {
 	if endpoint == "" {
 		return ""
 	}
@@ -28,9 +28,9 @@ func extractHostname(endpoint string) string {
 	return host
 }
 
-// resolveHostToIP resolves hostname to the first IP (IPv4/IPv6). It uses ctx so
+// ResolveHostToIP resolves the hostname to the first IP (IPv4/IPv6). It uses ctx so
 // cancellation/timeouts propagate.
-func resolveHostToIP(ctx context.Context, hostname string) (string, error) {
+func ResolveHostToIP(ctx context.Context, hostname string) (string, error) {
 	var r net.Resolver
 	ips, err := r.LookupIP(ctx, "ip", hostname)
 	if err != nil {

--- a/internal/services/util/output.go
+++ b/internal/services/util/output.go
@@ -39,7 +39,6 @@ func SplitTextByMaxWidth(text string) []string {
 
 	parts := strings.Fields(text)
 
-	// If there's only one part, or it's short enough, return it as is
 	if len(parts) <= 1 {
 		return []string{text}
 	}
@@ -49,7 +48,7 @@ func SplitTextByMaxWidth(text string) []string {
 
 	for i := 1; i < len(parts); i++ {
 		// If adding the next part makes the line too long, start a new line
-		if len(currentLine)+len(parts[i])+1 > 30 { // 30 is a reasonable width for the column
+		if len(currentLine)+len(parts[i])+1 > 30 {
 			result = append(result, currentLine)
 			currentLine = parts[i]
 		} else {

--- a/internal/services/util/output.go
+++ b/internal/services/util/output.go
@@ -20,7 +20,6 @@ func MarshalDataToJSONResponse[T any](p *printer.Printer, items []T, pagination 
 
 // FormatColoredTitle builds a colorized title string with tenancy, compartment, and cluster.
 func FormatColoredTitle(appCtx *app.ApplicationContext, name string) string {
-	// Create the colored title using components from the app context.
 	coloredTenancy := text.Colors{text.FgMagenta}.Sprint(appCtx.TenancyName)
 	coloredCompartment := text.Colors{text.FgCyan}.Sprint(appCtx.CompartmentName)
 	coloredName := text.Colors{text.FgBlue}.Sprint(name)
@@ -47,7 +46,6 @@ func SplitTextByMaxWidth(text string) []string {
 	currentLine := parts[0]
 
 	for i := 1; i < len(parts); i++ {
-		// If adding the next part makes the line too long, start a new line
 		if len(currentLine)+len(parts[i])+1 > 30 {
 			result = append(result, currentLine)
 			currentLine = parts[i]

--- a/internal/services/util/output_test.go
+++ b/internal/services/util/output_test.go
@@ -120,6 +120,5 @@ func TestSplitTextByMaxWidth(t *testing.T) {
 	// Test with a string that has multiple spaces
 	multiSpaceString := "This   string   has   multiple   spaces"
 	result = SplitTextByMaxWidth(multiSpaceString)
-	// The function uses strings.Fields which normalizes spaces, but also splits by max width
 	assert.Equal(t, []string{"This string has multiple", "spaces"}, result, "String with multiple spaces should be normalized and split if needed")
 }

--- a/internal/services/util/search_util.go
+++ b/internal/services/util/search_util.go
@@ -83,7 +83,7 @@ func FlattenTags(freeform map[string]string, defined map[string]map[string]inter
 	if freeform != nil {
 		for k, v := range freeform {
 			if k == "" || v == "" {
-				continue // skip empty keys/values
+				continue
 			}
 			parts = append(parts, fmt.Sprintf("%s:%s", strings.ToLower(k), strings.ToLower(v)))
 		}
@@ -99,8 +99,6 @@ func FlattenTags(freeform map[string]string, defined map[string]map[string]inter
 					continue
 				}
 
-				// You can restrict this to specific types if desired (e.g., string only)
-				// Convert to string safely
 				var valueStr string
 				switch val := v.(type) {
 				case string:
@@ -132,7 +130,7 @@ func ExtractTagValues(freeform map[string]string, defined map[string]map[string]
 	if freeform != nil {
 		for _, v := range freeform {
 			if v == "" {
-				continue // skip empty values
+				continue
 			}
 			values = append(values, strings.ToLower(v))
 		}
@@ -149,7 +147,6 @@ func ExtractTagValues(freeform map[string]string, defined map[string]map[string]
 					continue
 				}
 
-				// Convert to string safely
 				var valueStr string
 				switch val := v.(type) {
 				case string:

--- a/internal/services/util/search_util_test.go
+++ b/internal/services/util/search_util_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestFlattenTags tests the FlattenTags function

--- a/internal/services/util/search_util_test.go
+++ b/internal/services/util/search_util_test.go
@@ -137,8 +137,6 @@ func TestExtractTagValues(t *testing.T) {
 	}
 	result, err = ExtractTagValues(freeform, defined)
 	assert.NoError(t, err, "ExtractTagValues should not return an error with empty values")
-	// We can't use NotContains with an empty string because it would match the spaces between values
-	// Instead, we'll check that the result doesn't contain empty values by ensuring it doesn't have consecutive spaces
 	assert.NotContains(t, result, "  ", "ExtractTagValues should not have consecutive spaces (empty values)")
 	assert.Contains(t, result, "value2", "ExtractTagValues should include valid values")
 	assert.Contains(t, result, "value3", "ExtractTagValues should include valid values")

--- a/scripts/oci_auth_refresher.sh
+++ b/scripts/oci_auth_refresher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ───────────────────────────────────────────────────────────
-# oci_auth_refresher.sh  •  v0.2.1
+# oci_auth_refresher.sh  •  v0.2.2
 #
 # Keeps an OCI CLI session alive by refreshing it shortly
 # before it expires. Intended to be launched nohup
@@ -30,7 +30,7 @@ LOG_FILE="${SESSION_DIR}/refresher.log"
 
 mkdir -p "$SESSION_DIR"
 
-# Relaunch with nohup if needed
+# Relaunch with nohup
 if [[ -z "$NOHUP" && -t 1 ]]; then
   export NOHUP=1
   script_path="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
@@ -72,7 +72,7 @@ function to_epoch() {
 
 # Check remaining session duration
 function get_remaining_session_duration() {
-  if oci session validate --profile "$OCI_CLI_PROFILE" --local 2>&1; then
+  if oci session validate --profile "$OCI_CLI_PROFILE" --local >> "$LOG_FILE" 2>&1; then
     oci_session_status="valid"
     echo "$oci_session_status" > "$SESSION_STATUS_FILE"
 
@@ -126,7 +126,6 @@ function refresh_session() {
 oci_session_status="unknown"
 remaining_time=0
 
-# Main loop
 get_remaining_session_duration
 
 while [[ "$oci_session_status" == "valid" ]]; do

--- a/test_ocloud.sh
+++ b/test_ocloud.sh
@@ -94,13 +94,13 @@ print_header "Testing compute image command"
 run_command ./bin/ocloud compute image --help
 run_command ./bin/ocloud comp img --help
 
-# Test compute image list command
-print_header "Testing compute image list command"
-run_command ./bin/ocloud compute image list
-run_command ./bin/ocloud compute image list
-run_command ./bin/ocloud compute image list --limit 10 --page 1 --json
-run_command ./bin/ocloud compute image list -m 10 -p 1 -j
-run_command ./bin/ocloud comp img l
+# Test compute image get command
+print_header "Testing compute image get command"
+run_command ./bin/ocloud compute image get
+run_command ./bin/ocloud compute image get
+run_command ./bin/ocloud compute image get --limit 10 --page 1 --json
+run_command ./bin/ocloud compute image get -m 10 -p 1 -j
+run_command ./bin/ocloud comp img get
 
 # Test compute image find command
 print_header "Testing compute image find command"


### PR DESCRIPTION
- Improve code readability and consistency by reordering imports.
- Group related imports together, placing third-party libraries alphabetically after standard libraries.
- Add support for new branch naming conventions in build workflow (i.e., `refactor/*`).
- Clean `.gitignore` by alphabetizing and ensuring consistency in ignored files.
- Add tests to verify the inclusion and configuration of `list`, `get`, and `find` subcommands.
- Ensure `list` and `get` subcommands handle flags like `limit` and `page` properly.
- Confirm `JSON` is a global flag and excluded from local subcommand flags.