### PR TITLE
refactor: streamline service methods and simplify adapter imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Running `ocloud` without any arguments displays the configuration details and av
 ╚██████╔╝╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
  ╚═════╝  ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
 
-	      Version: 0.0.29
+	      Version: 0.0.30
 
 Configuration Details: Valid until 2025-08-02 23:26:28
   OCI_CLI_PROFILE: DEFAULT

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Running `ocloud` without any arguments displays the configuration details and av
 ╚██████╔╝╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
  ╚═════╝  ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
 
-	      Version: 0.0.30
+	      Version: 0.0.31
 
 Configuration Details: Valid until 2025-08-02 23:26:28
   OCI_CLI_PROFILE: DEFAULT

--- a/cmd/compute/image/find.go
+++ b/cmd/compute/image/find.go
@@ -67,10 +67,5 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running image find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
-
-	err := image.FindImages(appCtx, namePattern, useJSON)
-	if err != nil {
-		return err
-	}
-	return nil
+	return image.FindImages(appCtx, namePattern, useJSON)
 }

--- a/cmd/compute/image/get.go
+++ b/cmd/compute/image/get.go
@@ -61,16 +61,9 @@ func NewGetCmd(appCtx *app.ApplicationContext) *cobra.Command {
 
 // RunGetCommand handles the execution of the list command
 func RunGetCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running image list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON)
-
-	err := image.GetImages(appCtx, limit, page, useJSON)
-	if err != nil {
-		return err
-	}
-	return nil
+	return image.GetImages(appCtx, limit, page, useJSON)
 }

--- a/cmd/compute/image/list.go
+++ b/cmd/compute/image/list.go
@@ -49,10 +49,5 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	ctx := cmd.Context()
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running image list (TUI) command in", "compartment", appCtx.CompartmentName)
-
-	err := image.ListImages(ctx, appCtx)
-	if err != nil {
-		return err
-	}
-	return nil
+	return image.ListImages(ctx, appCtx)
 }

--- a/cmd/compute/instance/find.go
+++ b/cmd/compute/instance/find.go
@@ -68,10 +68,5 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	showDetails := flags.GetBoolFlag(cmd, flags.FlagNameAllInformation, false)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running instance find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
-	err := instance.FindInstances(appCtx, namePattern, useJSON, showDetails)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return instance.FindInstances(appCtx, namePattern, useJSON, showDetails)
 }

--- a/cmd/compute/instance/list.go
+++ b/cmd/compute/instance/list.go
@@ -74,11 +74,6 @@ func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	imageDetails := flags.GetBoolFlag(cmd, flags.FlagNameAllInformation, false)
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running instance list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON, "imageDetails", imageDetails)
-	err := instance.ListInstances(appCtx, useJSON, limit, page, imageDetails)
-	if err != nil {
-		return err
-	}
-	return nil
+	return instance.ListInstances(appCtx, useJSON, limit, page, imageDetails)
 }

--- a/cmd/compute/oke/find.go
+++ b/cmd/compute/oke/find.go
@@ -58,9 +58,5 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running oke find command", "pattern", namePattern, "in compartment", appCtx.CompartmentName, "json", useJSON)
-	err := oke.FindClusters(appCtx, namePattern, useJSON)
-	if err != nil {
-		return err
-	}
-	return nil
+	return oke.FindClusters(appCtx, namePattern, useJSON)
 }

--- a/cmd/compute/oke/list.go
+++ b/cmd/compute/oke/list.go
@@ -59,10 +59,5 @@ func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running oke list command in", "compartment", appCtx.CompartmentName, "json", useJSON)
-	err := oke.ListClusters(appCtx, useJSON, limit, page)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return oke.ListClusters(appCtx, useJSON, limit, page)
 }

--- a/cmd/configuration/auth/authenticate.go
+++ b/cmd/configuration/auth/authenticate.go
@@ -48,10 +48,5 @@ func RunAuthenticateCommand(cmd *cobra.Command) error {
 	filter := flags.GetStringFlag(cmd, flags.FlagNameFilter, "")
 	realm := flags.GetStringFlag(cmd, flags.FlagNameRealm, "")
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running authenticate command", "filter", filter, "realm", realm)
-	err := auth.AuthenticateWithOCI(filter, realm)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Authentication command completed.")
-	return nil
+	return auth.AuthenticateWithOCI(filter, realm)
 }

--- a/cmd/configuration/info/view_mapping_file.go
+++ b/cmd/configuration/info/view_mapping_file.go
@@ -62,9 +62,5 @@ func RunViewFileMappingCommand(cmd *cobra.Command) error {
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	realm := flags.GetStringFlag(cmd, flags.FlagNameRealm, "")
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running map-file command", "json", useJSON, "realm", realm)
-	err := info.ViewConfiguration(useJSON, realm)
-	if err != nil {
-		return err
-	}
-	return nil
+	return info.ViewConfiguration(useJSON, realm)
 }

--- a/cmd/configuration/setup/setup_mapping_file.go
+++ b/cmd/configuration/setup/setup_mapping_file.go
@@ -55,10 +55,5 @@ func SetupMappingFile() *cobra.Command {
 // RunSetupFileMappingCommand handles the execution of the setup command
 func RunSetupFileMappingCommand(cmd *cobra.Command) error {
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running setup command")
-	err := setup.SetupTenancyMapping()
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Setup command completed.")
-	return nil
+	return setup.SetupTenancyMapping()
 }

--- a/cmd/database/autonomousdb/find.go
+++ b/cmd/database/autonomousdb/find.go
@@ -3,9 +3,7 @@ package autonomousdb
 import (
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/config/flags"
-	"github.com/rozdolsky33/ocloud/internal/domain"
 	"github.com/rozdolsky33/ocloud/internal/logger"
-	ociadb "github.com/rozdolsky33/ocloud/internal/oci/database/autonomousdb"
 	"github.com/rozdolsky33/ocloud/internal/services/database/autonomousdb"
 	"github.com/spf13/cobra"
 )
@@ -60,25 +58,5 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running find command", "pattern", namePattern, "json", useJSON)
-
-	repo, err := ociadb.NewAdapter(appCtx.Provider, appCtx.CompartmentID)
-	if err != nil {
-		return err
-	}
-	service := autonomousdb.NewService(repo, appCtx)
-	databases, err := service.Find(cmd.Context(), namePattern)
-	if err != nil {
-		return err
-	}
-	// Convert a service type to a domain type for output
-	domainDbs := make([]domain.AutonomousDatabase, 0, len(databases))
-	for _, db := range databases {
-		domainDbs = append(domainDbs, domain.AutonomousDatabase(db))
-	}
-	err = autonomousdb.PrintAutonomousDbInfo(domainDbs, appCtx, nil, useJSON)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Autonomous DB find command completed.")
-	return nil
+	return autonomousdb.FindAutonomousDatabases(appCtx, namePattern, useJSON)
 }

--- a/cmd/database/autonomousdb/list.go
+++ b/cmd/database/autonomousdb/list.go
@@ -4,10 +4,7 @@ import (
 	paginationFlags "github.com/rozdolsky33/ocloud/cmd/flags"
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/config/flags"
-	"github.com/rozdolsky33/ocloud/internal/domain"
-	ociadb "github.com/rozdolsky33/ocloud/internal/oci/database/autonomousdb"
 	"github.com/rozdolsky33/ocloud/internal/services/database/autonomousdb"
-	"github.com/rozdolsky33/ocloud/internal/services/util"
 	"github.com/spf13/cobra"
 )
 
@@ -69,25 +66,5 @@ func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
-
-	repo, err := ociadb.NewAdapter(appCtx.Provider, appCtx.CompartmentID)
-	if err != nil {
-		return err
-	}
-	service := autonomousdb.NewService(repo, appCtx)
-	databases, totalCount, nextPageToken, err := service.List(cmd.Context(), limit, page)
-	if err != nil {
-		return err
-	}
-	// Convert a service type to a domain type for output
-	domainDbs := make([]domain.AutonomousDatabase, 0, len(databases))
-	for _, db := range databases {
-		domainDbs = append(domainDbs, domain.AutonomousDatabase(db))
-	}
-	return autonomousdb.PrintAutonomousDbInfo(domainDbs, appCtx, &util.PaginationInfo{
-		TotalCount:    totalCount,
-		Limit:         limit,
-		CurrentPage:   page,
-		NextPageToken: nextPageToken,
-	}, useJSON)
+	return autonomousdb.ListAutonomousDatabase(appCtx, useJSON, limit, page)
 }

--- a/cmd/database/root.go
+++ b/cmd/database/root.go
@@ -18,7 +18,6 @@ func NewDatabaseCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Add subcommands, passing in the ApplicationContext
 	cmd.AddCommand(autonomousdb.NewAutonomousDatabaseCmd(appCtx))
 
 	return cmd

--- a/cmd/identity/bastion/flows_oke.go
+++ b/cmd/identity/bastion/flows_oke.go
@@ -216,7 +216,7 @@ func connectOKE(ctx context.Context, appCtx *app.ApplicationContext, svc *bastio
 		if err != nil {
 			return fmt.Errorf("spawn detached: %w", err)
 		}
-		logger.Logger.V(1).Info("spawned tunnel", "pid", pid)
+		logger.Logger.V(logger.Debug).Info("spawned tunnel", "pid", pid)
 
 		if err := bastionSvc.WaitForListen(okeTargetPort, 5*time.Second); err != nil {
 			logger.Logger.Error(err, "warning")

--- a/cmd/identity/bastion/list.go
+++ b/cmd/identity/bastion/list.go
@@ -28,9 +28,5 @@ func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	ctx := cmd.Context()
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running list command")
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-	err := bastion.ListBastions(ctx, appCtx, useJSON)
-	if err != nil {
-		return err
-	}
-	return nil
+	return bastion.ListBastions(ctx, appCtx, useJSON)
 }

--- a/cmd/identity/compartment/find.go
+++ b/cmd/identity/compartment/find.go
@@ -60,11 +60,5 @@ func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationCo
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running find command", "pattern", namePattern, "json", useJSON)
-
-	err := compartment.FindCompartments(appCtx, namePattern, useJSON)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Compartment find command completed.")
-	return nil
+	return compartment.FindCompartments(appCtx, namePattern, useJSON)
 }

--- a/cmd/identity/compartment/list.go
+++ b/cmd/identity/compartment/list.go
@@ -65,17 +65,9 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 
 // RunListCommand handles the execution of the list command
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-	// Get pagination parameters
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	// Use LogWithLevel to ensure debug logs work with shorthand flags
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running compartment list command in", "compartment", appCtx.CompartmentName, "json", useJSON)
-	err := compartment.ListCompartments(appCtx, useJSON, limit, page)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Compartment list command completed.")
-	return nil
+	return compartment.ListCompartments(appCtx, useJSON, limit, page)
 }

--- a/cmd/identity/policy/find.go
+++ b/cmd/identity/policy/find.go
@@ -55,12 +55,6 @@ func NewFindCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationContext) error {
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running policy find command", "pattern", namePattern, "json", useJSON)
-	err := policy.FindPolicies(appCtx, namePattern, useJSON)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Policy find command completed.")
-	return nil
+	return policy.FindPolicies(appCtx, namePattern, useJSON)
 }

--- a/cmd/identity/policy/list.go
+++ b/cmd/identity/policy/list.go
@@ -56,7 +56,6 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 			return RunListCommand(cmd, appCtx)
 		},
 	}
-	// Add flags specific to the list command
 	paginationFlags.LimitFlag.Add(cmd)
 	paginationFlags.PageFlag.Add(cmd)
 
@@ -66,16 +65,9 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 
 // RunListCommand handles the execution of the list command
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-	// Get pagination parameters
 	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running policy list command in", "compartment", appCtx.CompartmentName, "json", useJSON)
-	err := policy.ListPolicies(appCtx, useJSON, limit, page)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Policy list command completed.")
-	return nil
+	return policy.ListPolicies(appCtx, useJSON, limit, page)
 }

--- a/cmd/network/subnet/find.go
+++ b/cmd/network/subnet/find.go
@@ -59,12 +59,6 @@ func NewFindCmd(appCtx *app.ApplicationContext) *cobra.Command {
 func RunFindCommand(cmd *cobra.Command, args []string, appCtx *app.ApplicationContext) error {
 	namePattern := args[0]
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running subnet find command", "pattern", namePattern, "json", useJSON)
-	err := subnet.FindSubnets(appCtx, namePattern, useJSON)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Subnet find command completed.")
-	return nil
+	return subnet.FindSubnets(appCtx, namePattern, useJSON)
 }

--- a/cmd/network/subnet/list.go
+++ b/cmd/network/subnet/list.go
@@ -73,12 +73,6 @@ func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
 	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
 	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
 	sortBy := flags.GetStringFlag(cmd, flags.FlagNameSort, "")
-
 	logger.LogWithLevel(logger.CmdLogger, logger.Debug, "Running subnet list command in", "compartment", appCtx.CompartmentName, "json", useJSON, "sort", sortBy)
-	err := subnet.ListSubnets(appCtx, useJSON, limit, page, sortBy)
-	if err != nil {
-		return err
-	}
-	logger.CmdLogger.V(logger.Info).Info("Subnet list command completed.")
-	return nil
+	return subnet.ListSubnets(appCtx, useJSON, limit, page, sortBy)
 }

--- a/internal/oci/identity/compartment/adapter.go
+++ b/internal/oci/identity/compartment/adapter.go
@@ -1,4 +1,4 @@
-package identity
+package compartment
 
 import (
 	"context"

--- a/internal/services/compute/image/get.go
+++ b/internal/services/compute/image/get.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/oci"
-	ociimage "github.com/rozdolsky33/ocloud/internal/oci/compute/image"
+	ociImage "github.com/rozdolsky33/ocloud/internal/oci/compute/image"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
@@ -17,7 +17,7 @@ func GetImages(appCtx *app.ApplicationContext, limit int, page int, useJSON bool
 		return fmt.Errorf("creating compute client: %w", err)
 	}
 
-	imageAdapter := ociimage.NewAdapter(computeClient)
+	imageAdapter := ociImage.NewAdapter(computeClient)
 	service := NewService(imageAdapter, appCtx.Logger, appCtx.CompartmentID)
 
 	images, totalCount, nextPageToken, err := service.Get(context.Background(), limit, page)

--- a/internal/services/compute/instance/list.go
+++ b/internal/services/compute/instance/list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/oci"
-	ociinstance "github.com/rozdolsky33/ocloud/internal/oci/compute/instance"
+	ociInst "github.com/rozdolsky33/ocloud/internal/oci/compute/instance"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
@@ -21,7 +21,7 @@ func ListInstances(appCtx *app.ApplicationContext, useJSON bool, limit, page int
 		return fmt.Errorf("creating network client: %w", err)
 	}
 
-	instanceAdapter := ociinstance.NewAdapter(computeClient, networkClient)
+	instanceAdapter := ociInst.NewAdapter(computeClient, networkClient)
 	service := NewService(instanceAdapter, appCtx.Logger, appCtx.CompartmentID)
 
 	instances, totalCount, nextPageToken, err := service.List(context.Background(), limit, page)

--- a/internal/services/configuration/auth/authenticate.go
+++ b/internal/services/configuration/auth/authenticate.go
@@ -10,28 +10,22 @@ import (
 // AuthenticateWithOCI handles the authentication process with Oracle Cloud Infrastructure (OCI) using interactive inputs.
 // It performs authentication with the provided filter and realm, displays environment variables, and optionally starts the auth refresher.
 func AuthenticateWithOCI(filter, realm string) error {
-
 	s := NewService()
-
-	logger.LogWithLevel(s.logger, 1, "Authenticating with OCI", "filter", filter, "realm", realm)
-
+	logger.LogWithLevel(s.logger, logger.Debug, "Authenticating with OCI", "filter", filter, "realm", realm)
 	result, err := s.performInteractiveAuthentication(filter, realm)
 	if err != nil {
 		return fmt.Errorf("performing interactive authentication: %w", err)
 	}
-
-	logger.LogWithLevel(s.logger, 3, "Interactive authentication completed", "tenancyID", result.TenancyID, "tenancyName", result.TenancyName)
-
-	logger.LogWithLevel(s.logger, 1, "Authentication process completed successfully")
-
+	logger.LogWithLevel(s.logger, logger.Debug, "Interactive authentication completed", "tenancyID", result.TenancyID, "tenancyName", result.TenancyName)
+	logger.LogWithLevel(s.logger, logger.Debug, "Authentication process completed successfully")
 	logger.LogWithLevel(s.logger, logger.Debug, "Starting OCI auth refresher for profile", "profile", result.Profile)
+	logger.CmdLogger.V(logger.Debug).Info("Prompting for OCI Auth Refresher setup...")
 
-	logger.CmdLogger.V(logger.Info).Info("Prompting for OCI Auth Refresher setup...")
 	if util.PromptYesNo("Do you want to set OCI_AUTH_AUTO_REFRESHER") {
 		if err := s.runOCIAuthRefresher(result.Profile); err != nil {
-			logger.LogWithLevel(s.logger, 1, "Failed to start OCI auth refresher", "error", err)
+			logger.LogWithLevel(s.logger, logger.Debug, "Failed to start OCI auth refresher", "error", err)
 		}
-		logger.LogWithLevel(s.logger, 1, "OCI auth refresher enabled")
+		logger.LogWithLevel(s.logger, logger.Debug, "OCI auth refresher enabled")
 	} else {
 		logger.LogWithLevel(s.logger, logger.Debug, "OCI auth refresher disabled")
 	}

--- a/internal/services/database/autonomousdb/find.go
+++ b/internal/services/database/autonomousdb/find.go
@@ -36,6 +36,5 @@ func FindAutonomousDatabases(appCtx *app.ApplicationContext, namePattern string,
 	if err := PrintAutonomousDbInfo(domainDbs, appCtx, nil, useJSON); err != nil {
 		return fmt.Errorf("printing autonomous databases: %w", err)
 	}
-	logger.Logger.V(logger.Info).Info("Autonomous Database find operation completed successfully.")
 	return nil
 }

--- a/internal/services/database/autonomousdb/list.go
+++ b/internal/services/database/autonomousdb/list.go
@@ -44,6 +44,5 @@ func ListAutonomousDatabase(appCtx *app.ApplicationContext, useJSON bool, limit,
 	}, useJSON); err != nil {
 		return fmt.Errorf("printing image table: %w", err)
 	}
-	logger.Logger.V(logger.Info).Info("Autonomous Database list operation completed successfully.")
 	return nil
 }

--- a/internal/services/identity/compartment/find.go
+++ b/internal/services/identity/compartment/find.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
-	"github.com/rozdolsky33/ocloud/internal/oci/identity"
+	"github.com/rozdolsky33/ocloud/internal/oci/identity/compartment"
 )
 
 // FindCompartments searches and displays compartments matching a given name pattern.
@@ -14,7 +14,7 @@ func FindCompartments(appCtx *app.ApplicationContext, namePattern string, useJSO
 	appCtx.Logger.V(logger.Debug).Info("finding compartments", "pattern", namePattern)
 
 	// Create the infrastructure adapter.
-	compartmentAdapter := identity.NewCompartmentAdapter(appCtx.IdentityClient, appCtx.TenancyID)
+	compartmentAdapter := compartment.NewCompartmentAdapter(appCtx.IdentityClient, appCtx.TenancyID)
 
 	// Create the application service, injecting the adapter.
 	service := NewService(compartmentAdapter, appCtx.Logger, appCtx.TenancyID)

--- a/internal/services/identity/compartment/list.go
+++ b/internal/services/identity/compartment/list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rozdolsky33/ocloud/internal/app"
 	"github.com/rozdolsky33/ocloud/internal/logger"
-	"github.com/rozdolsky33/ocloud/internal/oci/identity"
+	"github.com/rozdolsky33/ocloud/internal/oci/identity/compartment"
 	"github.com/rozdolsky33/ocloud/internal/services/util"
 )
 
@@ -15,7 +15,7 @@ func ListCompartments(appCtx *app.ApplicationContext, useJSON bool, limit, page 
 	appCtx.Logger.V(logger.Debug).Info("listing compartments", "limit", limit, "page", page)
 
 	// Create the infrastructure adapter.
-	compartmentAdapter := identity.NewCompartmentAdapter(appCtx.IdentityClient, appCtx.TenancyID)
+	compartmentAdapter := compartment.NewCompartmentAdapter(appCtx.IdentityClient, appCtx.TenancyID)
 
 	// Create the application service, injecting the adapter.
 	// The service is now decoupled from the OCI SDK.

--- a/internal/services/util/search_util.go
+++ b/internal/services/util/search_util.go
@@ -152,7 +152,6 @@ func ExtractTagValues(freeform map[string]string, defined map[string]map[string]
 				case string:
 					valueStr = val
 				default:
-					// fallback to fmt.Sprintf
 					valueStr = fmt.Sprintf("%v", val)
 				}
 


### PR DESCRIPTION
- Replace repetitive error handling with direct return statements for improved code conciseness.
- Adjust package imports by organizing and fixing naming conflicts (e.g., `identity` to `compartment`).
- Update README.md to reflect version bump from 0.0.30 to 0.0.31.