### PR TITLE
feat(bastion): add TUI-driven SCP upload and download flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ Whether you're exploring instances, working with databases, or need to quickly f
 - **Bastion**: Comprehensive bastion and session management
     - List and explore existing bastions
     - Create interactive bastion sessions with TUI-guided flows
-    - Connect to Compute Instances (Managed SSH, Port Forwarding & SCP)
+    - Connect to Compute Instances (Managed SSH, Port Forwarding, SCP Upload & SCP Download)
     - Connect to Databases (Autonomous DB, HeatWave, and OCI Cache via Port Forwarding)
     - Connect to OKE Clusters (Managed SSH to nodes & Port Forwarding to API server)
     - Connect to Load Balancers (Port Forwarding with TUI selection and health summaries)
-    - **TUI-driven SCP**: Securely copy files to private compute instances with interactive file picker and real-time progress
+    - **TUI-driven SCP Upload**: Securely copy files to private compute instances with interactive file picker and real-time progress
+    - **TUI-driven SCP Download**: Securely copy files or directories from private compute instances with real-time progress
     - Enhanced privileged port handling with sudo password validation
     - Automatic SSH tunnel management with background processes
     - Interactive SSH key pair selection
@@ -335,7 +336,7 @@ The `ocloud identity bastion create` command launches an interactive flow that g
 1. **Session Type Selection**: Choose between Bastion management or creating a new session
 2. **Bastion Selection**: Pick from your active bastions via TUI
 3. **Target Type Selection**: Choose your connection target (Instance, Database, OKE, or Load Balancer)
-4. **Session Type**: Select Managed SSH or Port Forwarding
+4. **Session Type**: Select Managed SSH, Port Forwarding, SCP Upload, or SCP Download
 5. **Resource Selection**: Interactive TUI to pick the specific resource
 6. **SSH Key Selection**: Choose your SSH key pair from `~/.ssh`
 7. **Connection Setup**: Automatic tunnel creation and configuration
@@ -350,11 +351,18 @@ ocloud identity bastion create
 # Select: Session → Choose Bastion → Instance → Managed SSH → Pick Instance → Select Keys
 ```
 
-**SCP (Secure Copy)**: Interactive file upload to private compute instances
+**SCP Upload**: Interactive file upload to private compute instances
 ```bash
 ocloud identity bastion create
-# Select: Session → Choose Bastion → Instance → SCP → Pick Instance → Select Keys → Select Local File → Enter Remote Path
+# Select: Session → Choose Bastion → Instance → SCP Upload → Pick Instance → Select Keys → Select Local File → Enter Remote Path
 # Uses TUI file picker and displays real-time progress
+```
+
+**SCP Download**: Interactive file or directory download from private compute instances
+```bash
+ocloud identity bastion create
+# Select: Session → Choose Bastion → Instance → SCP Download → Pick Instance → Select Keys → Enter Remote Path → Enter Local Path
+# Supports both files and directories (recursive copy) with real-time progress
 ```
 
 **Port Forwarding**: Create an SSH tunnel to instance ports (e.g., VNC, RDP, custom apps)

--- a/cmd/identity/bastion/flows.go
+++ b/cmd/identity/bastion/flows.go
@@ -97,9 +97,12 @@ func SelectSessionType(ctx context.Context, bastionID string, tType TargetType) 
 func ConnectTarget(ctx context.Context, appCtx *app.ApplicationContext, svc *bastionSvc.Service,
 	b bastionSvc.Bastion, sType SessionType, tType TargetType) error {
 
-	// SCP has its own dedicated flow
+	// SCP flows have their own dedicated orchestrators
 	if sType == TypeSCP {
 		return connectSCP(ctx, appCtx, svc, b)
+	}
+	if sType == TypeSCPDownload {
+		return connectSCPDownload(ctx, appCtx, svc, b)
 	}
 
 	switch tType {

--- a/cmd/identity/bastion/flows_scp_download.go
+++ b/cmd/identity/bastion/flows_scp_download.go
@@ -1,0 +1,166 @@
+package bastion
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rozdolsky33/ocloud/internal/app"
+	"github.com/rozdolsky33/ocloud/internal/logger"
+	"github.com/rozdolsky33/ocloud/internal/oci"
+	ociInst "github.com/rozdolsky33/ocloud/internal/oci/compute/instance"
+	instSvc "github.com/rozdolsky33/ocloud/internal/services/compute/instance"
+	bastionSvc "github.com/rozdolsky33/ocloud/internal/services/identity/bastion"
+	"github.com/rozdolsky33/ocloud/internal/services/util"
+	"github.com/rozdolsky33/ocloud/internal/tui"
+)
+
+// connectSCPDownload runs the SCP download flow for an Instance target:
+// 1. Select instance
+// 2. Select SSH key pair
+// 3. Prompt for remote file/directory path to download
+// 4. Prompt for local destination path
+// 5. Create managed SSH session
+// 6. Execute SCP download with progress
+func connectSCPDownload(ctx context.Context, appCtx *app.ApplicationContext, svc *bastionSvc.Service,
+	b bastionSvc.Bastion) error {
+
+	computeClient, err := oci.NewComputeClient(appCtx.Provider)
+	if err != nil {
+		return fmt.Errorf("creating compute client: %w", err)
+	}
+	networkClient, err := oci.NewNetworkClient(appCtx.Provider)
+	if err != nil {
+		return fmt.Errorf("creating network client: %w", err)
+	}
+	instanceAdapter := ociInst.NewAdapter(computeClient, networkClient)
+	instService := instSvc.NewService(instanceAdapter, appCtx.Logger, appCtx.CompartmentID)
+
+	instances, _, _, err := instService.FetchPaginatedInstances(ctx, 300, 0)
+	if err != nil {
+		return fmt.Errorf("list instances: %w", err)
+	}
+
+	if len(instances) == 0 {
+		logger.Logger.Info("No instances found.")
+		return nil
+	}
+
+	// Step 1: Select instance
+	im := NewInstanceListModelFancy(instances)
+	ip := tea.NewProgram(im, tea.WithContext(ctx))
+	ires, err := ip.Run()
+	if err != nil {
+		return fmt.Errorf("instance selection TUI: %w", err)
+	}
+	chosen, ok := ires.(ResourceListModel)
+	if !ok || chosen.Choice() == "" {
+		return ErrAborted
+	}
+
+	var inst instSvc.Instance
+	for _, it := range instances {
+		if it.OCID == chosen.Choice() {
+			inst = it
+			break
+		}
+	}
+
+	// Step 2: Select SSH key pair
+	pubKey, privKey, err := SelectSSHKeyPair(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Validate bastion can reach instance
+	if ok, reason := svc.CanReach(ctx, b, inst.VcnID, inst.SubnetID); !ok {
+		logger.Logger.Info("Bastion cannot reach selected instance", "reason", reason)
+		return nil
+	}
+
+	// Step 3: Prompt for remote file/directory path to download
+	remotePath, err := util.PromptString("Enter remote file or directory path to download", "")
+	if err != nil {
+		return fmt.Errorf("read remote path: %w", err)
+	}
+	if remotePath == "" {
+		logger.Logger.Info("No remote path specified, aborting.")
+		return nil
+	}
+
+	// Step 4: Prompt for local destination path
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	defaultLocal := filepath.Join(cwd, filepath.Base(remotePath))
+	localPath, err := util.PromptString("Enter local destination path", defaultLocal)
+	if err != nil {
+		return fmt.Errorf("read local path: %w", err)
+	}
+
+	// Step 5: Prompt for SSH username
+	sshUser, err := util.PromptString("Enter SSH username", "opc")
+	if err != nil {
+		return fmt.Errorf("read ssh username: %w", err)
+	}
+
+	logger.Logger.Info("Creating SCP download session",
+		"bastion", b.DisplayName,
+		"instance", inst.DisplayName,
+		"remote_path", remotePath,
+		"local_path", localPath,
+	)
+
+	// Step 6: Create managed SSH session (SCP uses managed SSH under the hood)
+	sessID, err := svc.EnsureManagedSSHSession(ctx, b.OCID, inst.OCID, inst.PrimaryIP, sshUser, 22, pubKey, 0)
+	if err != nil {
+		return fmt.Errorf("ensure managed SSH session for SCP download: %w", err)
+	}
+
+	region, regErr := appCtx.Provider.Region()
+	if regErr != nil {
+		return fmt.Errorf("get region: %w", regErr)
+	}
+
+	// Step 7: Build and execute SCP download command with progress TUI
+	scpCmd := bastionSvc.BuildSCPDownloadCommand(privKey, sessID, region, inst.PrimaryIP, sshUser, remotePath, localPath)
+
+	title := fmt.Sprintf("Downloading %s:%s to %s", inst.DisplayName, remotePath, localPath)
+	progressRunner := tui.NewProgressRunner(title)
+	progressRunner.Start()
+
+	done := make(chan error, 1)
+
+	go func() {
+		progressRunner.UpdateProgress(0.05, "", "", "Connecting via bastion...")
+
+		err := bastionSvc.RunShell(ctx, appCtx.Stdout, appCtx.Stderr, scpCmd)
+		if err != nil {
+			progressRunner.SendError(err)
+			done <- err
+			return
+		}
+
+		progressRunner.UpdateProgress(1.0, "", "", "Complete!")
+		done <- nil
+	}()
+
+	if err := progressRunner.Run(); err != nil {
+		return err
+	}
+
+	downloadErr := <-done
+	if downloadErr != nil {
+		return fmt.Errorf("SCP download: %w", downloadErr)
+	}
+
+	logger.Logger.Info("Successfully downloaded from remote instance",
+		"remote_path", remotePath,
+		"instance", inst.DisplayName,
+		"local_path", localPath,
+	)
+	return nil
+}

--- a/cmd/identity/bastion/flows_scp_download.go
+++ b/cmd/identity/bastion/flows_scp_download.go
@@ -20,8 +20,8 @@ import (
 // connectSCPDownload runs the SCP download flow for an Instance target:
 // 1. Select instance
 // 2. Select SSH key pair
-// 3. Prompt for remote file/directory path to download
-// 4. Prompt for local destination path
+// 3. Enter remote file/directory path (TUI text input)
+// 4. Enter local destination path (TUI text input)
 // 5. Create managed SSH session
 // 6. Execute SCP download with progress
 func connectSCPDownload(ctx context.Context, appCtx *app.ApplicationContext, svc *bastionSvc.Service,
@@ -80,25 +80,38 @@ func connectSCPDownload(ctx context.Context, appCtx *app.ApplicationContext, svc
 		return nil
 	}
 
-	// Step 3: Prompt for remote file/directory path to download
-	remotePath, err := util.PromptString("Enter remote file or directory path to download", "")
+	// Step 3: Enter remote file/directory path to download (TUI text input)
+	remoteInput := tui.NewTextInputModel(
+		"Enter remote file or directory path to download",
+		"/home/opc/example.log",
+		"",
+	)
+	remotePath, err := tui.RunTextInput(remoteInput)
 	if err != nil {
-		return fmt.Errorf("read remote path: %w", err)
+		return ErrAborted
 	}
 	if remotePath == "" {
 		logger.Logger.Info("No remote path specified, aborting.")
 		return nil
 	}
 
-	// Step 4: Prompt for local destination path
+	// Step 4: Enter local destination path (TUI text input)
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "."
 	}
 	defaultLocal := filepath.Join(cwd, filepath.Base(remotePath))
-	localPath, err := util.PromptString("Enter local destination path", defaultLocal)
+	localInput := tui.NewTextInputModel(
+		"Enter local destination path",
+		defaultLocal,
+		defaultLocal,
+	)
+	localPath, err := tui.RunTextInput(localInput)
 	if err != nil {
-		return fmt.Errorf("read local path: %w", err)
+		return ErrAborted
+	}
+	if localPath == "" {
+		localPath = defaultLocal
 	}
 
 	// Step 5: Prompt for SSH username

--- a/cmd/identity/bastion/tui_types.go
+++ b/cmd/identity/bastion/tui_types.go
@@ -40,7 +40,8 @@ const (
 type SessionType string
 
 const (
-	TypeSCP            SessionType = "SCP"
+	TypeSCP            SessionType = "SCP Upload"
+	TypeSCPDownload    SessionType = "SCP Download"
 	TypeManagedSSH     SessionType = "Managed SSH"
 	TypePortForwarding SessionType = "Port-Forwarding"
 )
@@ -183,7 +184,7 @@ type SessionTypeModel struct {
 func SessionTypesForTarget(tType TargetType) []SessionType {
 	switch tType {
 	case TargetInstance:
-		return []SessionType{TypeSCP, TypeManagedSSH, TypePortForwarding}
+		return []SessionType{TypeSCP, TypeSCPDownload, TypeManagedSSH, TypePortForwarding}
 	case TargetOKE:
 		return []SessionType{TypeManagedSSH, TypePortForwarding}
 	case TargetDatabase, TargetLoadBalancer:

--- a/internal/services/identity/bastion/session.go
+++ b/internal/services/identity/bastion/session.go
@@ -394,6 +394,16 @@ func BuildSCPCommand(privateKeyPath, sessionID, region, targetIP, targetUser, lo
 		privateKeyPath, bastionHostKeyOpts, proxy, localFile, targetUser, targetIP, remotePath)
 }
 
+// BuildSCPDownloadCommand constructs an SCP command that downloads a file or directory
+// from a remote instance through the bastion Managed SSH session.
+// The -r flag enables recursive copy so both files and directories work.
+func BuildSCPDownloadCommand(privateKeyPath, sessionID, region, targetIP, targetUser, remotePath, localPath string) string {
+	host := bastionHost(sessionID, region)
+	proxy := fmt.Sprintf("ssh -i %s %s -W %%h:%%p -p 22 %s@%s", privateKeyPath, bastionHostKeyOpts, sessionID, host)
+	return fmt.Sprintf("scp -r -i %s %s -o ProxyCommand=\"%s\" -P 22 %s@%s:%s %s",
+		privateKeyPath, bastionHostKeyOpts, proxy, targetUser, targetIP, remotePath, localPath)
+}
+
 // BuildManagedSSHCommand constructs the SSH command that uses ProxyCommand with the bastion Managed SSH session.
 // It opens only a direct-tcpip channel on the bastion (accepted), while authenticating to bastion with the session OCID.
 // The outer SSH connects to the target instance as targetUser@targetIP.

--- a/internal/tui/textinput.go
+++ b/internal/tui/textinput.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TextInputModel is a Bubble Tea model for a single-line text input with a prompt.
+type TextInputModel struct {
+	textInput textinput.Model
+	header    string
+	footer    string
+	confirmed bool
+	quitting  bool
+}
+
+// NewTextInputModel creates a text input TUI with the given prompt, placeholder, and default value.
+func NewTextInputModel(header, placeholder, defaultValue string) TextInputModel {
+	ti := textinput.New()
+	ti.Placeholder = placeholder
+	ti.Focus()
+	ti.CharLimit = 512
+	ti.Width = 60
+	if defaultValue != "" {
+		ti.SetValue(defaultValue)
+	}
+
+	return TextInputModel{
+		textInput: ti,
+		header:    header,
+		footer:    "(enter to confirm, esc to cancel)",
+	}
+}
+
+func (m TextInputModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m TextInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			m.confirmed = true
+			m.quitting = true
+			return m, tea.Quit
+		case "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m TextInputModel) View() string {
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("170"))
+	footerStyle := lipgloss.NewStyle().Faint(true)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		"",
+		headerStyle.Render(m.header),
+		"",
+		m.textInput.View(),
+		"",
+		footerStyle.Render(m.footer),
+		"",
+	)
+}
+
+// Value returns the text input value.
+func (m TextInputModel) Value() string { return m.textInput.Value() }
+
+// RunTextInput runs the text input TUI and returns the entered value.
+// Returns ErrCancelled if the user quit without confirming.
+func RunTextInput(m TextInputModel) (string, error) {
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return "", err
+	}
+	if mm, ok := finalModel.(TextInputModel); ok {
+		if !mm.confirmed {
+			return "", ErrCancelled
+		}
+		return mm.Value(), nil
+	}
+	return "", ErrCancelled
+}


### PR DESCRIPTION
- Split SCP functionality into separate "Upload" and "Download" session types.
- Implemented TUI-driven flows for interactive file selection and real-time progress tracking.
- Enhanced session type selection to include SCP Upload and SCP Download.
- Updated README with detailed instructions for SCP Upload and Download.